### PR TITLE
malloc() is located in stdlib.h, not malloc.h.

### DIFF
--- a/config.c
+++ b/config.c
@@ -18,7 +18,6 @@
 
 #include <string.h>
 #include <stdio.h>
-#include <malloc.h>
 #include <stdlib.h>
 
 #include "build_options.h"

--- a/file_utils.c
+++ b/file_utils.c
@@ -20,7 +20,7 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <stdio.h>
-#include <malloc.h>
+#include <stdlib.h>
 #include <errno.h>
 #include <string.h>
 #include <time.h>

--- a/font_utils.c
+++ b/font_utils.c
@@ -19,7 +19,6 @@
 #include <stdarg.h>
 #include <string.h>
 #include <stdio.h>
-#include <malloc.h>
 
 #include "debug_utils.h"
 #include "png/png_utils.h"

--- a/gb_core/interrupts.c
+++ b/gb_core/interrupts.c
@@ -16,7 +16,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <malloc.h>
 #include <time.h>
 
 #include "../build_options.h"

--- a/gb_core/mbc.c
+++ b/gb_core/mbc.c
@@ -17,7 +17,6 @@
 */
 
 #include <stdio.h>
-#include <malloc.h>
 #include <stdlib.h>
 #include <string.h>
 

--- a/gb_core/ppu.c
+++ b/gb_core/ppu.c
@@ -16,8 +16,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <malloc.h>
-
 #include "../build_options.h"
 #include "../debug_utils.h"
 

--- a/gb_core/rom.c
+++ b/gb_core/rom.c
@@ -16,7 +16,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <malloc.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>

--- a/gb_core/video.c
+++ b/gb_core/video.c
@@ -17,7 +17,6 @@
 */
 
 #include <stdio.h>
-#include <malloc.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdarg.h>

--- a/gba_core/memory.c
+++ b/gba_core/memory.c
@@ -16,7 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <malloc.h>
+#include <stdlib.h>
 #include <string.h>
 
 #include "../build_options.h"

--- a/gui/win_gb_sgbviewer.c
+++ b/gui/win_gb_sgbviewer.c
@@ -19,7 +19,6 @@
 #include <SDL2/SDL.h>
 
 #include <string.h>
-#include <malloc.h>
 
 #include "../debug_utils.h"
 #include "../window_handler.h"

--- a/gui/win_gba_mapviewer.c
+++ b/gui/win_gba_mapviewer.c
@@ -19,7 +19,6 @@
 #include <SDL2/SDL.h>
 
 #include <string.h>
-#include <malloc.h>
 
 #include "../debug_utils.h"
 #include "../window_handler.h"

--- a/gui/win_gba_sprviewer.c
+++ b/gui/win_gba_sprviewer.c
@@ -19,7 +19,6 @@
 #include <SDL2/SDL.h>
 
 #include <string.h>
-#include <malloc.h>
 
 #include "../debug_utils.h"
 #include "../window_handler.h"

--- a/gui/win_gba_tileviewer.c
+++ b/gui/win_gba_tileviewer.c
@@ -19,7 +19,6 @@
 #include <SDL2/SDL.h>
 
 #include <string.h>
-#include <malloc.h>
 
 #include "../debug_utils.h"
 #include "../window_handler.h"

--- a/gui/win_main.c
+++ b/gui/win_main.c
@@ -19,7 +19,6 @@
 #include <SDL2/SDL.h>
 #include <string.h>
 #include <ctype.h>
-#include <malloc.h>
 
 #include "win_main.h"
 #include "win_utils.h"

--- a/png/png_utils.c
+++ b/png/png_utils.c
@@ -16,7 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <malloc.h>
+#include <stdlib.h>
 
 #include <png.h>
 


### PR DESCRIPTION
In ISO standard C and POSIX, malloc() is defined in stdlib.h. On OpenBSD, #including malloc.h prints this message:

`<malloc.h> is obsolete, use <stdlib.h>`

So let’s use it.