### PR TITLE
Don't abort on SDL init failure, in case it's something minor like rumble.

### DIFF
--- a/main.c
+++ b/main.c
@@ -38,7 +38,6 @@ static int Init(void)
     if( SDL_Init(SDL_INIT_EVERYTHING) != 0 )
     {
         Debug_LogMsgArg( "SDL could not initialize! SDL Error: %s\n", SDL_GetError() );
-        return 1;
     }
     atexit(SDL_Quit);
 


### PR DESCRIPTION
`Init()` calls `SDL_Init(SDL_INIT_EVERYTHING)`, and quits the program if there’s an error. But this shouldn’t necessarily be fatal. For example, on OpenBSD SDL2 isn’t built with rumble support (yet). That means that currently, giibiiadvance logs “SDL could not initialize! SDL Error: Couldn't init SDL haptic subsystem: SDL not built with haptic (force feedback) support” and then immediately exits.

If I delete the check so that the emulator continues, everything works fine (except rumble, of course). The log contains messages like “Couldn't open haptic for joystick 0: Haptic: There are 0 haptic devices available”, which is informative enough—aborting the program is too much.