### PR TITLE
It's safe to use snprintf, because by definition it null terminates.

### DIFF
--- a/config.c
+++ b/config.c
@@ -108,7 +108,7 @@ static const char * serialdevice[] = { "None", "GBPrinter" }; //, "Gameboy" };
 void Config_Save(void)
 {
     char path[MAX_PATHLEN];
-    if(DirGetRunningPath()) s_snprintf(path,sizeof(path),"%sGiiBiiAdvance.ini",DirGetRunningPath());
+    if(DirGetRunningPath()) snprintf(path,sizeof(path),"%sGiiBiiAdvance.ini",DirGetRunningPath());
     else s_strncpy(path,"GiiBiiAdvance.ini",sizeof(path));
     FILE * ini_file = fopen(path,"wb");
     if(ini_file == NULL) return;
@@ -203,7 +203,7 @@ void Config_Load(void)
     GB_ConfigSetPalette(0xB0,0xFF,0xB0);
 
     char path[MAX_PATHLEN];
-    if(DirGetRunningPath()) s_snprintf(path,sizeof(path),"%sGiiBiiAdvance.ini",DirGetRunningPath());
+    if(DirGetRunningPath()) snprintf(path,sizeof(path),"%sGiiBiiAdvance.ini",DirGetRunningPath());
     else s_strncpy(path,"GiiBiiAdvance.ini",sizeof(path));
 
     char * ini;
@@ -434,7 +434,7 @@ void Config_Load(void)
         char temp_str[64];
         if(player > 0)
         {
-            s_snprintf(temp_str,sizeof(temp_str),"P%d_Enabled=",player+1);
+            snprintf(temp_str,sizeof(temp_str),"P%d_Enabled=",player+1);
             tmp = strstr(ini,temp_str);
             if(tmp)
             {
@@ -452,7 +452,7 @@ void Config_Load(void)
 
         if(player_enabled) // read the rest of the configuration
         {
-            s_snprintf(temp_str,sizeof(temp_str),"P%d_Controller=[",player+1);
+            snprintf(temp_str,sizeof(temp_str),"P%d_Controller=[",player+1);
             tmp = strstr(ini,temp_str);
             if(tmp)
             {
@@ -476,7 +476,7 @@ void Config_Load(void)
                     //now, read keys
                     for(key = 0; key < P_NUM_KEYS; key ++)
                     {
-                        s_snprintf(temp_str,sizeof(temp_str),"P%d_%s=",player+1,GBKeyNames[key]);
+                        snprintf(temp_str,sizeof(temp_str),"P%d_%s=",player+1,GBKeyNames[key]);
                         tmp = strstr(ini,temp_str);
                         if(tmp)
                         {

--- a/debug_utils.c
+++ b/debug_utils.c
@@ -51,7 +51,7 @@ void Debug_Init(void)
 
     // remove previous log files
     char logpath[MAX_PATHLEN];
-    s_snprintf(logpath,sizeof(logpath),"%slog.txt",DirGetRunningPath());
+    snprintf(logpath,sizeof(logpath),"%slog.txt",DirGetRunningPath());
     if(FileExists(logpath))
     {
         remove(logpath); // if returns 0, ok
@@ -63,7 +63,7 @@ void Debug_LogMsgArg(const char * msg, ...)
     if(log_file_opened == 0)
     {
         char logpath[MAX_PATHLEN];
-        s_snprintf(logpath,sizeof(logpath),"%slog.txt",DirGetRunningPath());
+        snprintf(logpath,sizeof(logpath),"%slog.txt",DirGetRunningPath());
         f_log = fopen(logpath,"w");
         if(f_log)
             log_file_opened = 1;

--- a/file_explorer.c
+++ b/file_explorer.c
@@ -205,7 +205,7 @@ int FileExplorer_LoadFolder(void)
             break;
 
         char checkingfile[MAX_PATHLEN];
-        s_snprintf(checkingfile,sizeof(checkingfile),"%s%s",exploring_path,pent->d_name);
+        snprintf(checkingfile,sizeof(checkingfile),"%s%s",exploring_path,pent->d_name);
 
         stat(checkingfile,&statbuf);
         FileExplorer_ListAdd(pent->d_name,(S_ISDIR(statbuf.st_mode))!=0);
@@ -252,7 +252,7 @@ int FileExplorer_SelectEntry(char * file)
     }
 
     char file_path[MAX_PATHLEN];
-    s_snprintf(file_path,sizeof(file_path),"%s%s",exploring_path,file);
+    snprintf(file_path,sizeof(file_path),"%s%s",exploring_path,file);
     struct stat statbuf;
     stat(file_path,&statbuf);
     //Debug_DebugMsgArg("stat(%s)",file_path);

--- a/file_utils.c
+++ b/file_utils.c
@@ -65,8 +65,8 @@ void DirSetRunningPath(char * path)
         running_path[2] = '\0';
     }
 
-    s_snprintf(bios_path,sizeof(bios_path),"%s%s%c",running_path,BIOS_FOLDER,slash_char);
-    s_snprintf(screenshot_path,sizeof(screenshot_path),"%s%s%c",running_path,SCREENSHOT_FOLDER,slash_char);
+    snprintf(bios_path,sizeof(bios_path),"%s%s%c",running_path,BIOS_FOLDER,slash_char);
+    snprintf(screenshot_path,sizeof(screenshot_path),"%s%s%c",running_path,SCREENSHOT_FOLDER,slash_char);
 }
 
 char * DirGetRunningPath(void)
@@ -237,12 +237,12 @@ char * FU_GetNewTimestampFilename(const char * basename)
     struct tm * ptm = gmtime(&rawtime);
 
     char timestamp[50];
-    s_snprintf(timestamp,sizeof(timestamp),"%04d%02d%02d_%02d%02d%02d",1900+ptm->tm_year,1+ptm->tm_mon,ptm->tm_mday,
+    snprintf(timestamp,sizeof(timestamp),"%04d%02d%02d_%02d%02d%02d",1900+ptm->tm_year,1+ptm->tm_mon,ptm->tm_mday,
                1+ptm->tm_hour,ptm->tm_min,ptm->tm_sec);
 
     while(1)
     {
-        s_snprintf(_fu_filename,sizeof(_fu_filename),"%s%s_%s_%d.png",DirGetScreenshotFolderPath(),basename,
+        snprintf(_fu_filename,sizeof(_fu_filename),"%s%s_%s_%d.png",DirGetScreenshotFolderPath(),basename,
                    timestamp,number);
 
         FILE * file=fopen(_fu_filename, "rb");

--- a/gb_core/debug.c
+++ b/gb_core/debug.c
@@ -451,7 +451,7 @@ char * GB_Dissasemble(u16 addr, int * step)
         if(paramsize == 0)
         {
             *step = 1;
-            s_snprintf(text,sizeof(text),"%02X       %s",cmd,debug_commands[cmd]);
+            snprintf(text,sizeof(text),"%02X       %s",cmd,debug_commands[cmd]);
             info = debug_commands_info[cmd];
             param = 0;
         }
@@ -480,7 +480,7 @@ char * GB_Dissasemble(u16 addr, int * step)
                     char temp[32];
                     s_strncpy(temp, debug_commands[cmd], sizeof(temp));
                     info = debug_commands_info[cmd];
-                    s_snprintf(instr_text,sizeof(instr_text),temp,param);
+                    snprintf(instr_text,sizeof(instr_text),temp,param);
                 }
             }
             else
@@ -488,10 +488,10 @@ char * GB_Dissasemble(u16 addr, int * step)
                 char temp[32];
                 s_strncpy(temp, debug_commands[cmd], sizeof(temp));
                 info = debug_commands_info[cmd];
-                s_snprintf(instr_text,sizeof(instr_text),temp,param);
+                snprintf(instr_text,sizeof(instr_text),temp,param);
             }
 
-            s_snprintf(text,sizeof(text),"%02X%02X     %s",cmd,param,instr_text);
+            snprintf(text,sizeof(text),"%02X%02X     %s",cmd,param,instr_text);
             *step = 2;
         }
         else if(paramsize == 2)
@@ -505,9 +505,9 @@ char * GB_Dissasemble(u16 addr, int * step)
             param = param1 | (param2 << 8);
             char temp[32];
             s_strncpy(temp, debug_commands[cmd], sizeof(temp));
-            s_snprintf(instr_text,sizeof(instr_text),temp,param);
+            snprintf(instr_text,sizeof(instr_text),temp,param);
             info = debug_commands_info[cmd];
-            s_snprintf(text,sizeof(text),"%02X%02X%02X   %s",cmd,param1,param2,instr_text);
+            snprintf(text,sizeof(text),"%02X%02X%02X   %s",cmd,param1,param2,instr_text);
             *step = 3;
         }
         else if(paramsize == 3) //jump relative
@@ -516,9 +516,9 @@ char * GB_Dissasemble(u16 addr, int * step)
             char temp[32];
             char instr_text[64];
             s_strncpy(temp, debug_commands[cmd], sizeof(temp));
-            s_snprintf(instr_text,sizeof(instr_text),temp,(param + addr) & 0xFFFF);
+            snprintf(instr_text,sizeof(instr_text),temp,(param + addr) & 0xFFFF);
             info = debug_commands_info[cmd];
-            s_snprintf(text,sizeof(text),"%02X%02X     %s",cmd,(u8)param,instr_text);
+            snprintf(text,sizeof(text),"%02X%02X     %s",cmd,(u8)param,instr_text);
             param = param + addr;
             *step = 2;
         }
@@ -599,7 +599,7 @@ char * GB_Dissasemble(u16 addr, int * step)
     else //not code...
     {
         u8 data = GB_MemRead8(addr);
-        s_snprintf(text,sizeof(text),"%02X       db 0x%02X",data,data);
+        snprintf(text,sizeof(text),"%02X       db 0x%02X",data,data);
         *step = 1;
     }
 

--- a/gb_core/rom.c
+++ b/gb_core/rom.c
@@ -296,7 +296,7 @@ int GB_CartridgeLoad(const u8 * pointer, const u32 rom_size)
             {
                 int size = strlen(DirGetBiosFolderPath()) + strlen(boot_rom_filename) + 2;
                 char * completepath = malloc(size);
-                s_snprintf(completepath,size,"%s%s",DirGetBiosFolderPath(),boot_rom_filename);
+                snprintf(completepath,size,"%s%s",DirGetBiosFolderPath(),boot_rom_filename);
                 FILE * test = fopen(completepath,"rb");
                 if(test)
                 {
@@ -760,7 +760,7 @@ void GB_SRAM_Save(void)
 
     int size = strlen(GameBoy.Emulator.save_filename) + 5;
     char * name = malloc(size);
-    s_snprintf(name,size,"%s.sav",GameBoy.Emulator.save_filename);
+    snprintf(name,size,"%s.sav",GameBoy.Emulator.save_filename);
 
     FILE * savefile = fopen (name,"wb+");
 
@@ -809,7 +809,7 @@ void GB_SRAM_Load(void)
 
     int size = strlen(GameBoy.Emulator.save_filename) + 5;
     char * name = malloc(size);
-    s_snprintf(name,size,"%s.sav",GameBoy.Emulator.save_filename);
+    snprintf(name,size,"%s.sav",GameBoy.Emulator.save_filename);
 
     FILE * savefile = fopen (name,"rb");
 

--- a/gba_core/disassembler.c
+++ b/gba_core/disassembler.c
@@ -356,9 +356,9 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                                 //[Rn, <#{+/-}expression>]{!}
                                 u32 offset = ((opcode>>4)&0xF0)|(opcode&0xF);
                                 if(offset)
-                                    s_snprintf(addr_text,sizeof(addr_text),"[r%d, #%s0x%08X]%s",Rn,sign,offset, writeback);
+                                    snprintf(addr_text,sizeof(addr_text),"[r%d, #%s0x%08X]%s",Rn,sign,offset, writeback);
                                 else
-                                    s_snprintf(addr_text,sizeof(addr_text),"[r%d]%s",Rn, writeback);
+                                    snprintf(addr_text,sizeof(addr_text),"[r%d]%s",Rn, writeback);
                                 addr += (opcode & BIT(23)) ? offset : -offset;
                             }
                             else //Register as offset
@@ -366,7 +366,7 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                                 //[Rn, {+/-}Rm]{!}
                                 //11-8 must be 0000
                                 u32 Rm = opcode&0xF; //(not including R15)
-                                s_snprintf(addr_text,sizeof(addr_text),"[r%d, %sr%d]%s",Rn,sign,Rm, writeback);
+                                snprintf(addr_text,sizeof(addr_text),"[r%d, %sr%d]%s",Rn,sign,Rm, writeback);
                             }
                         }
                         else //Post-indexed
@@ -376,16 +376,16 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                                 //[Rn], <#{+/-}expression>
                                 u32 offset = ((opcode>>4)&0xF0)|(opcode&0xF);
                                 if(offset)
-                                    s_snprintf(addr_text,sizeof(addr_text),"[r%d], #%s0x%08X",Rn,sign,offset);
+                                    snprintf(addr_text,sizeof(addr_text),"[r%d], #%s0x%08X",Rn,sign,offset);
                                 else
-                                    s_snprintf(addr_text,sizeof(addr_text),"[r%d]",Rn);
+                                    snprintf(addr_text,sizeof(addr_text),"[r%d]",Rn);
                             }
                             else //Register as offset
                             {
                                 //[Rn], {+/-}Rm
                                 //11-8 must be 0000
                                 u32 Rm = opcode&0xF; //(not including R15)
-                                s_snprintf(addr_text,sizeof(addr_text),"[r%d], %sr%d",Rn,sign,Rm);
+                                snprintf(addr_text,sizeof(addr_text),"[r%d], %sr%d",Rn,sign,Rm);
                             }
                         }
 
@@ -398,12 +398,12 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                                 // LDR{cond}H  Rd,<Address>  ;Load Unsigned halfword (zero-extended)
                                 if(writeresult)
                                 {
-                                    s_snprintf(dest,dest_size,"ldr%sh r%d, =0x%08X",cond,Rd,(u32)GBA_MemoryRead16(addr&~1));
+                                    snprintf(dest,dest_size,"ldr%sh r%d, =0x%08X",cond,Rd,(u32)GBA_MemoryRead16(addr&~1));
                                     gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                                 }
                                 else
                                 {
-                                    s_snprintf(dest,dest_size,"ldr%sh r%d, %s",cond,Rd,addr_text);
+                                    snprintf(dest,dest_size,"ldr%sh r%d, %s",cond,Rd,addr_text);
                                     int comment = gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                                     gba_dissasemble_add_io_register_name(addr,dest,!comment,dest_size);
                                 }
@@ -414,12 +414,12 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                                 // LDR{cond}SB Rd,<Address>  ;Load Signed byte (sign extended)
                                 if(writeresult)
                                 {
-                                    s_snprintf(dest,dest_size,"ldr%ssb r%d, =0x%08X",cond,Rd,(s32)(s8)GBA_MemoryRead8(address));
+                                    snprintf(dest,dest_size,"ldr%ssb r%d, =0x%08X",cond,Rd,(s32)(s8)GBA_MemoryRead8(address));
                                     gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                                 }
                                 else
                                 {
-                                    s_snprintf(dest,dest_size,"ldr%ssb r%d, %s",cond,Rd,addr_text);
+                                    snprintf(dest,dest_size,"ldr%ssb r%d, %s",cond,Rd,addr_text);
                                     int comment = gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                                     gba_dissasemble_add_io_register_name(addr,dest,!comment,dest_size);
                                 }
@@ -430,12 +430,12 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                                 // LDR{cond}SH Rd,<Address>  ;Load Signed halfword (sign extended)
                                 if(writeresult)
                                 {
-                                    s_snprintf(dest,dest_size,"ldr%ssh r%d, =0x%08X",cond,Rd,(s32)(s16)GBA_MemoryRead16(address&~1));
+                                    snprintf(dest,dest_size,"ldr%ssh r%d, =0x%08X",cond,Rd,(s32)(s16)GBA_MemoryRead16(address&~1));
                                     gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                                 }
                                 else
                                 {
-                                    s_snprintf(dest,dest_size,"ldr%ssh r%d, %s",cond,Rd,addr_text);
+                                    snprintf(dest,dest_size,"ldr%ssh r%d, %s",cond,Rd,addr_text);
                                     int comment = gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                                     gba_dissasemble_add_io_register_name(addr,dest,!comment,dest_size);
                                 }
@@ -451,7 +451,7 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                             }
 
                             // STR{cond}H  Rd,<Address>  ;Store halfword
-                            s_snprintf(dest,dest_size,"str%sh r%d, %s",cond,Rd,addr_text);
+                            snprintf(dest,dest_size,"str%sh r%d, %s",cond,Rd,addr_text);
                             int comment = gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                             gba_dissasemble_add_io_register_name(addr,dest,!comment,dest_size);
                             return;
@@ -474,7 +474,7 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                             u32 Rd = (opcode>>12)&0xF; // | r0 - r14
                             u32 Rm = opcode&0xF;       // |
 
-                            s_snprintf(dest,dest_size,"swp%s%s r%d, r%d, [r%d]",cond,bytemode,Rd,Rm,Rn);
+                            snprintf(dest,dest_size,"swp%s%s r%d, r%d, [r%d]",cond,bytemode,Rd,Rm,Rn);
                             int comment = gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                             gba_dissasemble_add_io_register_name(CPU.R[Rn],dest,!comment,dest_size);
                             return;
@@ -492,15 +492,15 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
 
                             switch(op)
                             {
-                                case 0: s_snprintf(dest,dest_size,"mul%s%s r%d, r%d, r%d",cond,setcond,Rd,Rm,Rs); break;
-                                case 1: s_snprintf(dest,dest_size,"mla%s%s r%d, r%d, r%d, r%d",cond,setcond,Rd,Rm,Rs,Rn); break;
+                                case 0: snprintf(dest,dest_size,"mul%s%s r%d, r%d, r%d",cond,setcond,Rd,Rm,Rs); break;
+                                case 1: snprintf(dest,dest_size,"mla%s%s r%d, r%d, r%d, r%d",cond,setcond,Rd,Rm,Rs,Rn); break;
                                 case 2: case 3:
                                     s_strncpy(dest,"[!] Undefined Instruction #0-2",dest_size);
                                     return;
-                                case 4: s_snprintf(dest,dest_size,"umull%s%s r%d, r%d, r%d, r%d",cond,setcond,Rn,Rd,Rm,Rs); break;
-                                case 5: s_snprintf(dest,dest_size,"umlal%s%s r%d, r%d, r%d, r%d",cond,setcond,Rn,Rd,Rm,Rs); break;
-                                case 6: s_snprintf(dest,dest_size,"smull%s%s r%d, r%d, r%d, r%d",cond,setcond,Rn,Rd,Rm,Rs); break;
-                                case 7: s_snprintf(dest,dest_size,"smlal%s%s r%d, r%d, r%d, r%d",cond,setcond,Rn,Rd,Rm,Rs); break;
+                                case 4: snprintf(dest,dest_size,"umull%s%s r%d, r%d, r%d, r%d",cond,setcond,Rn,Rd,Rm,Rs); break;
+                                case 5: snprintf(dest,dest_size,"umlal%s%s r%d, r%d, r%d, r%d",cond,setcond,Rn,Rd,Rm,Rs); break;
+                                case 6: snprintf(dest,dest_size,"smull%s%s r%d, r%d, r%d, r%d",cond,setcond,Rn,Rd,Rm,Rs); break;
+                                case 7: snprintf(dest,dest_size,"smlal%s%s r%d, r%d, r%d, r%d",cond,setcond,Rn,Rd,Rm,Rs); break;
                             }
                             gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                             return;
@@ -515,12 +515,12 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                         u32 Rn = opcode&0xF;
                         if(CPU.R[Rn] & 1) //Switch to THUMB
                         {
-                            s_snprintf(dest,dest_size,"bx%s r%d ; Switch to THUMB",cond,Rn); //PC=Rn-1, T=Rn.0
+                            snprintf(dest,dest_size,"bx%s r%d ; Switch to THUMB",cond,Rn); //PC=Rn-1, T=Rn.0
                             gba_dissasemble_add_condition_met(arm_cond_code,address,dest,0,dest_size);
                         }
                         else
                         {
-                            s_snprintf(dest,dest_size,"bx%s r%d",cond,Rn); //PC=Rn, T=Rn.0
+                            snprintf(dest,dest_size,"bx%s r%d",cond,Rn); //PC=Rn, T=Rn.0
                             gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                         }
                         return;
@@ -548,22 +548,22 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
 
                     switch(op)
                     {
-                        case 0: s_snprintf(dest,dest_size,"and%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
-                        case 1: s_snprintf(dest,dest_size,"eor%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
-                        case 2: s_snprintf(dest,dest_size,"sub%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
-                        case 3: s_snprintf(dest,dest_size,"rsb%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
-                        case 4: s_snprintf(dest,dest_size,"add%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
-                        case 5: s_snprintf(dest,dest_size,"adc%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
-                        case 6: s_snprintf(dest,dest_size,"sbc%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
-                        case 7: s_snprintf(dest,dest_size,"rsc%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
-                        case 8: s_snprintf(dest,dest_size,"tst%s r%d, r%d, %s r%d",cond,Rn,Rm,shift,Rs); break;
-                        case 9: s_snprintf(dest,dest_size,"teq%s r%d, r%d, %s r%d",cond,Rn,Rm,shift,Rs); break;
-                        case 0xA: s_snprintf(dest,dest_size,"cmp%s r%d, r%d, %s r%d",cond,Rn,Rm,shift,Rs); break;
-                        case 0xB: s_snprintf(dest,dest_size,"cmn%s r%d, r%d, %s r%d",cond,Rn,Rm,shift,Rs); break;
-                        case 0xC: s_snprintf(dest,dest_size,"orr%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
-                        case 0xD: s_snprintf(dest,dest_size,"mov%s%s r%d, r%d, %s r%d",cond,setcond,Rd,Rm,shift,Rs); break;
-                        case 0xE: s_snprintf(dest,dest_size,"bic%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
-                        case 0xF: s_snprintf(dest,dest_size,"mvn%s%s r%d, r%d, %s r%d",cond,setcond,Rd,Rm,shift,Rs); break;
+                        case 0: snprintf(dest,dest_size,"and%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
+                        case 1: snprintf(dest,dest_size,"eor%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
+                        case 2: snprintf(dest,dest_size,"sub%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
+                        case 3: snprintf(dest,dest_size,"rsb%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
+                        case 4: snprintf(dest,dest_size,"add%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
+                        case 5: snprintf(dest,dest_size,"adc%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
+                        case 6: snprintf(dest,dest_size,"sbc%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
+                        case 7: snprintf(dest,dest_size,"rsc%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
+                        case 8: snprintf(dest,dest_size,"tst%s r%d, r%d, %s r%d",cond,Rn,Rm,shift,Rs); break;
+                        case 9: snprintf(dest,dest_size,"teq%s r%d, r%d, %s r%d",cond,Rn,Rm,shift,Rs); break;
+                        case 0xA: snprintf(dest,dest_size,"cmp%s r%d, r%d, %s r%d",cond,Rn,Rm,shift,Rs); break;
+                        case 0xB: snprintf(dest,dest_size,"cmn%s r%d, r%d, %s r%d",cond,Rn,Rm,shift,Rs); break;
+                        case 0xC: snprintf(dest,dest_size,"orr%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
+                        case 0xD: snprintf(dest,dest_size,"mov%s%s r%d, r%d, %s r%d",cond,setcond,Rd,Rm,shift,Rs); break;
+                        case 0xE: snprintf(dest,dest_size,"bic%s%s r%d, r%d, r%d, %s r%d",cond,setcond,Rd,Rn,Rm,shift,Rs); break;
+                        case 0xF: snprintf(dest,dest_size,"mvn%s%s r%d, r%d, %s r%d",cond,setcond,Rd,Rm,shift,Rs); break;
                     }
                     gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                     return;
@@ -577,13 +577,13 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
 
                     if(opcode & BIT(22)) //MRS{cond} Rd,spsr
                     {
-                        s_snprintf(dest,dest_size,"mrs%s r%d,spsr",cond,Rd);
+                        snprintf(dest,dest_size,"mrs%s r%d,spsr",cond,Rd);
                         gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                         return;
                     }
                     else //MRS{cond} Rd,cpsr
                     {
-                        s_snprintf(dest,dest_size,"mrs%s r%d,cpsr",cond,Rd);
+                        snprintf(dest,dest_size,"mrs%s r%d,cpsr",cond,Rd);
                         gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                         return;
                     }
@@ -601,7 +601,7 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                     if(opcode & BIT(16)) fields[cursor++] = 'c'; //7-0
                     fields[cursor] = '\0';
 
-                    s_snprintf(dest,dest_size,"msr%s cpsr_%s, r%d",cond,fields,Rm);
+                    snprintf(dest,dest_size,"msr%s cpsr_%s, r%d",cond,fields,Rm);
                     gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                     return;
                 }
@@ -616,7 +616,7 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                     if(opcode & BIT(16)) fields[cursor++] = 'c'; //7-0
                     fields[cursor] = '\0';
 
-                    s_snprintf(dest,dest_size,"msr%s spsr_%s, r%d",cond,fields,Rm);
+                    snprintf(dest,dest_size,"msr%s spsr_%s, r%d",cond,fields,Rm);
                     gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                     return;
                 }
@@ -649,38 +649,38 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                         default:
                         case 0: temp[0] = '\0'; if((opcode & BIT(20)) == 0) canbenop = 1; break;
                         case 1: case 2:
-                            shiftval = 32; s_snprintf(temp,sizeof(temp),", %s #0x%02X",shift,shiftval); break;
+                            shiftval = 32; snprintf(temp,sizeof(temp),", %s #0x%02X",shift,shiftval); break;
                         case 3: s_strncpy(temp,", rrx",sizeof(temp)); break;
                     }
                 }
                 else
                 {
-                    s_snprintf(temp,sizeof(temp),", %s #0x%02X",shift,shiftval);
+                    snprintf(temp,sizeof(temp),", %s #0x%02X",shift,shiftval);
                 }
 
                 switch(op)
                 {
-                    case 0: s_snprintf(dest,dest_size,"and%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;;
-                    case 1: s_snprintf(dest,dest_size,"eor%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
-                    case 2: s_snprintf(dest,dest_size,"sub%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
-                    case 3: s_snprintf(dest,dest_size,"rsb%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
-                    case 4: s_snprintf(dest,dest_size,"add%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
-                    case 5: s_snprintf(dest,dest_size,"adc%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
-                    case 6: s_snprintf(dest,dest_size,"sbc%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
-                    case 7: s_snprintf(dest,dest_size,"rsc%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
-                    case 8: s_snprintf(dest,dest_size,"tst%s r%d, r%d%s",cond,Rn,Rm,temp); break;
-                    case 9: s_snprintf(dest,dest_size,"teq%s r%d, r%d%s",cond,Rn,Rm,temp); break;
-                    case 0xA: s_snprintf(dest,dest_size,"cmp%s r%d, r%d%s",cond,Rn,Rm,temp); break;
-                    case 0xB: s_snprintf(dest,dest_size,"cmn%s r%d, r%d%s",cond,Rn,Rm,temp); break;
-                    case 0xC: s_snprintf(dest,dest_size,"orr%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
+                    case 0: snprintf(dest,dest_size,"and%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;;
+                    case 1: snprintf(dest,dest_size,"eor%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
+                    case 2: snprintf(dest,dest_size,"sub%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
+                    case 3: snprintf(dest,dest_size,"rsb%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
+                    case 4: snprintf(dest,dest_size,"add%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
+                    case 5: snprintf(dest,dest_size,"adc%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
+                    case 6: snprintf(dest,dest_size,"sbc%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
+                    case 7: snprintf(dest,dest_size,"rsc%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
+                    case 8: snprintf(dest,dest_size,"tst%s r%d, r%d%s",cond,Rn,Rm,temp); break;
+                    case 9: snprintf(dest,dest_size,"teq%s r%d, r%d%s",cond,Rn,Rm,temp); break;
+                    case 0xA: snprintf(dest,dest_size,"cmp%s r%d, r%d%s",cond,Rn,Rm,temp); break;
+                    case 0xB: snprintf(dest,dest_size,"cmn%s r%d, r%d%s",cond,Rn,Rm,temp); break;
+                    case 0xC: snprintf(dest,dest_size,"orr%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
                     case 0xD:
                         if( (canbenop) && ((Rd|Rm) == 0) )
-                            s_snprintf(dest,dest_size,"nop%s",cond);
+                            snprintf(dest,dest_size,"nop%s",cond);
                         else
-                            s_snprintf(dest,dest_size,"mov%s%s r%d, r%d%s",cond,setcond,Rd,Rm,temp);
+                            snprintf(dest,dest_size,"mov%s%s r%d, r%d%s",cond,setcond,Rd,Rm,temp);
                         break;
-                    case 0xE: s_snprintf(dest,dest_size,"bic%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
-                    case 0xF: s_snprintf(dest,dest_size,"mvn%s%s r%d, r%d%s",cond,setcond,Rd,Rm,temp); break;
+                    case 0xE: snprintf(dest,dest_size,"bic%s%s r%d, r%d, r%d%s",cond,setcond,Rd,Rn,Rm,temp); break;
+                    case 0xF: snprintf(dest,dest_size,"mvn%s%s r%d, r%d%s",cond,setcond,Rd,Rm,temp); break;
                 }
                 gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                 return;
@@ -701,7 +701,7 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                 if(opcode & BIT(17)) fields[cursor++] = 'x';
                 if(opcode & BIT(16)) fields[cursor++] = 'c'; //7-0
                 fields[cursor] = '\0';
-                s_snprintf(dest,dest_size,"msr%s %s_%s, #0x%08X",cond,dst,fields,value);
+                snprintf(dest,dest_size,"msr%s %s_%s, #0x%08X",cond,dst,fields,value);
                 gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                 return;
             }
@@ -724,22 +724,22 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
 
             switch(op)
             {
-                case 0: s_snprintf(dest,dest_size,"and%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
-                case 1: s_snprintf(dest,dest_size,"eor%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
-                case 2: s_snprintf(dest,dest_size,"sub%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
-                case 3: s_snprintf(dest,dest_size,"rsb%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
-                case 4: s_snprintf(dest,dest_size,"add%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
-                case 5: s_snprintf(dest,dest_size,"adc%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
-                case 6: s_snprintf(dest,dest_size,"sbc%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
-                case 7: s_snprintf(dest,dest_size,"rsc%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
-                case 8: s_snprintf(dest,dest_size,"tst%s r%d, #0x%08X",cond,Rn,val); break;
-                case 9: s_snprintf(dest,dest_size,"teq%s r%d, #0x%08X",cond,Rn,val); break;
-                case 0xA: s_snprintf(dest,dest_size,"cmp%s r%d, #0x%08X",cond,Rn,val); break;
-                case 0xB: s_snprintf(dest,dest_size,"cmn%s r%d, #0x%08X",cond,Rn,val); break;
-                case 0xC: s_snprintf(dest,dest_size,"orr%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
-                case 0xD: s_snprintf(dest,dest_size,"mov%s%s r%d, #0x%08X",cond,setcond,Rd,val); break;
-                case 0xE: s_snprintf(dest,dest_size,"bic%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
-                case 0xF: s_snprintf(dest,dest_size,"mvn%s%s r%d, #0x%08X",cond,setcond,Rd,val); break;
+                case 0: snprintf(dest,dest_size,"and%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
+                case 1: snprintf(dest,dest_size,"eor%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
+                case 2: snprintf(dest,dest_size,"sub%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
+                case 3: snprintf(dest,dest_size,"rsb%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
+                case 4: snprintf(dest,dest_size,"add%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
+                case 5: snprintf(dest,dest_size,"adc%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
+                case 6: snprintf(dest,dest_size,"sbc%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
+                case 7: snprintf(dest,dest_size,"rsc%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
+                case 8: snprintf(dest,dest_size,"tst%s r%d, #0x%08X",cond,Rn,val); break;
+                case 9: snprintf(dest,dest_size,"teq%s r%d, #0x%08X",cond,Rn,val); break;
+                case 0xA: snprintf(dest,dest_size,"cmp%s r%d, #0x%08X",cond,Rn,val); break;
+                case 0xB: snprintf(dest,dest_size,"cmn%s r%d, #0x%08X",cond,Rn,val); break;
+                case 0xC: snprintf(dest,dest_size,"orr%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
+                case 0xD: snprintf(dest,dest_size,"mov%s%s r%d, #0x%08X",cond,setcond,Rd,val); break;
+                case 0xE: snprintf(dest,dest_size,"bic%s%s r%d, r%d, #0x%08X",cond,setcond,Rd,Rn,val); break;
+                case 0xF: snprintf(dest,dest_size,"mvn%s%s r%d, #0x%08X",cond,setcond,Rd,val); break;
                 default: break;
             }
             gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
@@ -762,17 +762,17 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
             if(opcode & BIT(24)) //Pre-indexed
             {
                 if(offset)
-                    s_snprintf(addr_text,sizeof(addr_text),"[r%d, #%s0x%03X]%s",Rn,sign,offset, opcode & BIT(21) ? "!":"");
+                    snprintf(addr_text,sizeof(addr_text),"[r%d, #%s0x%03X]%s",Rn,sign,offset, opcode & BIT(21) ? "!":"");
                 else
-                    s_snprintf(addr_text,sizeof(addr_text),"[r%d]%s",Rn, opcode & BIT(21) ? "!":"");
+                    snprintf(addr_text,sizeof(addr_text),"[r%d]%s",Rn, opcode & BIT(21) ? "!":"");
             }
             else //Post-indexed
             {
                 forceuser = (opcode & BIT(21)) ? "t" : "";
                 if(offset)
-                    s_snprintf(addr_text,sizeof(addr_text),"[r%d], #%s0x%03X",Rn,sign,offset);
+                    snprintf(addr_text,sizeof(addr_text),"[r%d], #%s0x%03X",Rn,sign,offset);
                 else
-                    s_snprintf(addr_text,sizeof(addr_text),"[r%d]",Rn);
+                    snprintf(addr_text,sizeof(addr_text),"[r%d]",Rn);
             }
 
             u32 addr = address;
@@ -782,19 +782,19 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                 if(Rn==R_PC)
                 {
                     if(opcode & BIT(24)) addr += 8 + ( (opcode & BIT(23)) ? offset : -offset); //Pre-indexed
-                    if(opcode & BIT(22)) s_snprintf(dest,dest_size,"ldr%s%s%s r%d, =0x%08X",cond,bytemode,forceuser,Rd,GBA_MemoryRead32(addr)&0xFF);
-                    else s_snprintf(dest,dest_size,"ldr%s%s%s r%d, =0x%08X",cond,bytemode,forceuser,Rd,GBA_MemoryRead32(addr));
+                    if(opcode & BIT(22)) snprintf(dest,dest_size,"ldr%s%s%s r%d, =0x%08X",cond,bytemode,forceuser,Rd,GBA_MemoryRead32(addr)&0xFF);
+                    else snprintf(dest,dest_size,"ldr%s%s%s r%d, =0x%08X",cond,bytemode,forceuser,Rd,GBA_MemoryRead32(addr));
                 }
                 else
                 {
                     if(opcode & BIT(24)) addr += ( (opcode & BIT(23)) ? offset : -offset); //Pre-indexed
-                    s_snprintf(dest,dest_size,"ldr%s%s%s r%d, %s",cond,bytemode,forceuser,Rd,addr_text);
+                    snprintf(dest,dest_size,"ldr%s%s%s r%d, %s",cond,bytemode,forceuser,Rd,addr_text);
                 }
             }
             else // STR{cond}{B}{T} Rd,<Address>
             {
                 if(opcode & BIT(24)) addr += ( (opcode & BIT(23)) ? offset : -offset); //Pre-indexed
-                s_snprintf(dest,dest_size,"str%s%s%s r%d, %s",cond,bytemode,forceuser,Rd,addr_text);
+                snprintf(dest,dest_size,"str%s%s%s r%d, %s",cond,bytemode,forceuser,Rd,addr_text);
             }
             int comment = gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
             gba_dissasemble_add_io_register_name(CPU.R[Rn],dest,!comment,dest_size);
@@ -829,14 +829,14 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                 switch((opcode>>5)&3)
                 {
                     default:
-                    case 0: s_snprintf(shift_text,sizeof(shift_text),"r%d",Rm); break;
-                    case 1: case 2: shiftval = 32; s_snprintf(shift_text,sizeof(shift_text),"r%d, %s #%02X",Rm,shift,shiftval); break;
-                    case 3: s_snprintf(shift_text,sizeof(shift_text),"r%d, rrx",Rm); break;
+                    case 0: snprintf(shift_text,sizeof(shift_text),"r%d",Rm); break;
+                    case 1: case 2: shiftval = 32; snprintf(shift_text,sizeof(shift_text),"r%d, %s #%02X",Rm,shift,shiftval); break;
+                    case 3: snprintf(shift_text,sizeof(shift_text),"r%d, rrx",Rm); break;
                 }
             }
             else
             {
-                s_snprintf(shift_text,sizeof(shift_text),"r%d, %s #%02X",Rm,shift,shiftval);
+                snprintf(shift_text,sizeof(shift_text),"r%d, %s #%02X",Rm,shift,shiftval);
             }
 
 
@@ -845,7 +845,7 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
             char addr_text[32];
             if(opcode & BIT(24)) //Pre-indexed
             {
-                s_snprintf(addr_text,sizeof(addr_text),"[r%d, %s%s]%s",Rn,sign,shift_text,opcode & BIT(21) ? "!":"");
+                snprintf(addr_text,sizeof(addr_text),"[r%d, %s%s]%s",Rn,sign,shift_text,opcode & BIT(21) ? "!":"");
                 s32 offset = cpu_shift_by_reg_no_carry_arm_ldr_str(
                                         (opcode>>5)&3,CPU.R[opcode&0xF],(opcode>>7)&0x1F);
                 addr += (opcode & BIT(23)) ? offset : -offset;
@@ -853,16 +853,16 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
             else //Post-indexed
             {
                 forceuser = (opcode & BIT(21)) ? "t" : "";
-                s_snprintf(addr_text,sizeof(addr_text),"[r%d], %s%s",Rn,sign,shift_text);
+                snprintf(addr_text,sizeof(addr_text),"[r%d], %s%s",Rn,sign,shift_text);
             }
 
             if(opcode & BIT(20)) // LDR{cond}{B}{T} Rd,<Address>
             {
-                s_snprintf(dest,dest_size,"ldr%s%s%s r%d, %s",cond,bytemode,forceuser,Rd,addr_text);
+                snprintf(dest,dest_size,"ldr%s%s%s r%d, %s",cond,bytemode,forceuser,Rd,addr_text);
             }
             else // STR{cond}{B}{T} Rd,<Address>
             {
-                s_snprintf(dest,dest_size,"str%s%s%s r%d, %s",cond,bytemode,forceuser,Rd,addr_text);
+                snprintf(dest,dest_size,"str%s%s%s r%d, %s",cond,bytemode,forceuser,Rd,addr_text);
             }
             int comment = gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
             gba_dissasemble_add_io_register_name(addr,dest,!comment,dest_size);
@@ -900,14 +900,14 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
             {
                 if(opcode & BIT(i))
                 {
-                    char reg[4]; s_snprintf(reg,sizeof(reg),"r%d",i);
+                    char reg[4]; snprintf(reg,sizeof(reg),"r%d",i);
                     s_strncat(reglist,reg,sizeof(reglist));
                     if( (opcode & BIT(i+1)) && (opcode & BIT(i+2)) )
                     {
                         s_strncat(reglist,"-",sizeof(reglist));
                         while(opcode & BIT(i++));
                         i-=2;
-                        s_snprintf(reg,sizeof(reg),"r%d",i);
+                        snprintf(reg,sizeof(reg),"r%d",i);
                         s_strncat(reglist,reg,sizeof(reglist));
                     }
 
@@ -921,7 +921,7 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
             if(load)
             {
                 // LDM{cond}{amod} Rn{!},<Rlist>{^}
-                s_snprintf(dest,dest_size,"ldm%s%s%s r%d%s, %s%s",cond,sign,increment_time,Rn,writeback,
+                snprintf(dest,dest_size,"ldm%s%s%s r%d%s, %s%s",cond,sign,increment_time,Rn,writeback,
                         reglist,usrmod);
                 if(is_pop)
                     s_strncat(dest," ; pop",dest_size); // ldmia r13! == pop
@@ -929,7 +929,7 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
             else
             {
                 // STM{cond}{amod} Rn{!},<Rlist>{^}
-                s_snprintf(dest,dest_size,"stm%s%s%s r%d%s, %s%s",cond,sign,increment_time,Rn,writeback,
+                snprintf(dest,dest_size,"stm%s%s%s r%d%s, %s%s",cond,sign,increment_time,Rn,writeback,
                         reglist,usrmod);
                 if(is_push)
                     s_strncat(dest," ; push",dest_size); // stmdb r13! == push
@@ -942,7 +942,7 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
             if(opcode & (1<<24)) //BL{cond}
             {
                 u32 nn = (opcode & 0x00FFFFFF);
-                s_snprintf(dest,dest_size,"bl%s #0x%08X",cond,address+8+
+                snprintf(dest,dest_size,"bl%s #0x%08X",cond,address+8+
                         ( ((nn & BIT(23)) ? (nn|0xFF000000) : nn)*4 ) );
                 s_strncat(dest," ; ->",dest_size);
                 gba_dissasemble_add_condition_met(arm_cond_code,address,dest,0,dest_size);
@@ -952,7 +952,7 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
             {
                 u32 nn = (opcode & 0x00FFFFFF);
                 u32 addr_dest = address+8+ ( ((nn & BIT(23)) ? (nn|0xFF000000) : nn)*4 );
-                s_snprintf(dest,dest_size,"b%s #0x%08X",cond,addr_dest);
+                snprintf(dest,dest_size,"b%s #0x%08X",cond,addr_dest);
                 if(addr_dest > address) s_strncat(dest," ; " STR_SLIM_ARROW_DOWN,dest_size);
                 else if(addr_dest == address) s_strncat(dest," ; <-",dest_size);
                 else s_strncat(dest," ; " STR_SLIM_ARROW_UP,dest_size);
@@ -977,28 +977,28 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
             if(opcode & BIT(24)) //Pre
             {
                 if(offset)
-                    s_snprintf(addr_text,sizeof(addr_text),"[r%d, #%s0x%03X]%s",Rn,sign,offset,writeback);
+                    snprintf(addr_text,sizeof(addr_text),"[r%d, #%s0x%03X]%s",Rn,sign,offset,writeback);
                 else
-                    s_snprintf(addr_text,sizeof(addr_text),"[r%d]%s",Rn,writeback);
+                    snprintf(addr_text,sizeof(addr_text),"[r%d]%s",Rn,writeback);
             }
             else //Post
             {
                 //Always writeback?
                 if(offset)
-                    s_snprintf(addr_text,sizeof(addr_text),"[r%d], #%s0x%03X",Rn,sign,offset);
+                    snprintf(addr_text,sizeof(addr_text),"[r%d], #%s0x%03X",Rn,sign,offset);
                 else
-                    s_snprintf(addr_text,sizeof(addr_text),"[r%d]",Rn);
+                    snprintf(addr_text,sizeof(addr_text),"[r%d]",Rn);
             }
 
             if(opcode & BIT(20)) // LDC{cond}{L} Pn,Cd,<Address>
             {
-                s_snprintf(dest,dest_size,"ldc%s%s p%d, c%d, %s ; [!]",cond,length,Pn,Cd,addr_text);
+                snprintf(dest,dest_size,"ldc%s%s p%d, c%d, %s ; [!]",cond,length,Pn,Cd,addr_text);
                 gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                 return;
             }
             else // STC{cond}{L} Pn,Cd,<Address>
             {
-                s_snprintf(dest,dest_size,"stc%s%s p%d, c%d, %s ; [!]",cond,length,Pn,Cd,addr_text);
+                snprintf(dest,dest_size,"stc%s%s p%d, c%d, %s ; [!]",cond,length,Pn,Cd,addr_text);
                 gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                 return;
             }
@@ -1008,7 +1008,7 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
             if(opcode & BIT(24))
             {
                 //SWI{cond}
-                s_snprintf(dest,dest_size,"swi%s #0x%06X",cond,(opcode & 0x00FFFFFF));
+                snprintf(dest,dest_size,"swi%s #0x%06X",cond,(opcode & 0x00FFFFFF));
                 int comment = gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                 gba_disassemble_swi_name((opcode & 0x00FFFFFF)>>16,dest,!comment,dest_size);
                 return;
@@ -1027,13 +1027,13 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
 
                     if(opcode & BIT(20)) // MRC{cond} Pn,<cpopc>,Rd,Cn,Cm{,<cp>}
                     {
-                        s_snprintf(dest,dest_size,"mrc%s p%d, #0x%01X, r%d, c%d, c%d, #0x%01X ; [!]",cond,Pn,CP_Opc,Rd,Cn,Cm,CP);
+                        snprintf(dest,dest_size,"mrc%s p%d, #0x%01X, r%d, c%d, c%d, #0x%01X ; [!]",cond,Pn,CP_Opc,Rd,Cn,Cm,CP);
                         gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                         return;
                     }
                     else // MCR{cond} Pn,<cpopc>,Rd,Cn,Cm{,<cp>}
                     {
-                        s_snprintf(dest,dest_size,"mcr%s p%d, #0x%01X, r%d, c%d, c%d, #0x%01X ; [!]",cond,Pn,CP_Opc,Rd,Cn,Cm,CP);
+                        snprintf(dest,dest_size,"mcr%s p%d, #0x%01X, r%d, c%d, c%d, #0x%01X ; [!]",cond,Pn,CP_Opc,Rd,Cn,Cm,CP);
                         gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                         return;
                     }
@@ -1048,7 +1048,7 @@ void GBA_DisassembleARM(u32 opcode, u32 address, char * dest, int dest_size)
                     u32 CP = (opcode>>5) & 7;
                     u32 Cm = opcode & 0xF;
 
-                    s_snprintf(dest,dest_size,"cdp%s p%d, #0x%01X, c%d, c%d, c%d, #0x%01X ; [!]",cond,Pn,CP_Opc,Cd,Cn,Cm,CP);
+                    snprintf(dest,dest_size,"cdp%s p%d, #0x%01X, c%d, c%d, c%d, #0x%01X ; [!]",cond,Pn,CP_Opc,Cd,Cn,Cm,CP);
                     gba_dissasemble_add_condition_met(arm_cond_code,address,dest,1,dest_size);
                     return;
                 }
@@ -1086,13 +1086,13 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
             {
                 //LSR Rd,Rs,#Offset
                 if(immed == 0) immed = 32;//LSR#0: Interpreted as LSR#32
-                s_snprintf(dest,dest_size,"lsr r%d, r%d, #0x%02X",Rd,Rs,immed);
+                snprintf(dest,dest_size,"lsr r%d, r%d, #0x%02X",Rd,Rs,immed);
                 return;
             }
             else
             {
                 //LSL Rd,Rs,#Offset
-                s_snprintf(dest,dest_size,"lsl r%d, r%d, #0x%02X",Rd,Rs,immed);
+                snprintf(dest,dest_size,"lsl r%d, r%d, #0x%02X",Rd,Rs,immed);
                 return;
             }
             break;
@@ -1109,28 +1109,28 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                     case 0: //ADD Rd,Rs,Rn
                     {
                         u16 Rn = (opcode>>6) & 7;
-                        s_snprintf(dest,dest_size,"add r%d, r%d, r%d",Rd,Rs,Rn);
+                        snprintf(dest,dest_size,"add r%d, r%d, r%d",Rd,Rs,Rn);
                         return;
                     }
                     case 1: //SUB Rd,Rs,Rn
                     {
                         u16 Rn = (opcode>>6) & 7;
-                        s_snprintf(dest,dest_size,"sub r%d, r%d, r%d",Rd,Rs,Rn);
+                        snprintf(dest,dest_size,"sub r%d, r%d, r%d",Rd,Rs,Rn);
                         return;
                     }
                     case 2: //ADD Rd,Rs,#nn
                     {
                         u16 immed = (opcode >> 6) & 0x7;
                         if(immed)
-                            s_snprintf(dest,dest_size,"add r%d, r%d, #0x%01X",Rd,Rs,immed);
+                            snprintf(dest,dest_size,"add r%d, r%d, #0x%01X",Rd,Rs,immed);
                         else
-                            s_snprintf(dest,dest_size,"mov r%d, r%d",Rd,Rs);
+                            snprintf(dest,dest_size,"mov r%d, r%d",Rd,Rs);
                         return;
                     }
                     case 3: //SUB Rd,Rs,#nn
                     {
                         u16 immed = (opcode >> 6) & 0x7;
-                        s_snprintf(dest,dest_size,"sub r%d, r%d, #0x%01X",Rd,Rs,immed);
+                        snprintf(dest,dest_size,"sub r%d, r%d, #0x%01X",Rd,Rs,immed);
                         return;
                     }
                 }
@@ -1143,7 +1143,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                 u16 immed = (opcode >> 6) & 0x1F;
 
                 if(immed == 0) immed = 32;//ASR#0: Interpreted as ASR#32
-                s_snprintf(dest,dest_size,"asr r%d, r%d, #0x%02X",Rd,Rs,immed);
+                snprintf(dest,dest_size,"asr r%d, r%d, #0x%02X",Rd,Rs,immed);
                 return;
             }
             break;
@@ -1156,13 +1156,13 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
             if(opcode & BIT(11))
             {
                 //CMP Rd,#nn
-                s_snprintf(dest,dest_size,"cmp r%d, #0x%02X",Rd,immed);
+                snprintf(dest,dest_size,"cmp r%d, #0x%02X",Rd,immed);
                 return;
             }
             else
             {
                 //MOV Rd,#nn
-                s_snprintf(dest,dest_size,"mov r%d, #0x%02X",Rd,immed);
+                snprintf(dest,dest_size,"mov r%d, #0x%02X",Rd,immed);
                 return;
             }
             break;
@@ -1175,13 +1175,13 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
             if(opcode & BIT(11))
             {
                 //SUB Rd,#nn
-                s_snprintf(dest,dest_size,"sub r%d, #0x%02X",Rd,immed);
+                snprintf(dest,dest_size,"sub r%d, #0x%02X",Rd,immed);
                 return;
             }
             else
             {
                 //ADD Rd,#nn
-                s_snprintf(dest,dest_size,"add r%d, #0x%02X",Rd,immed);
+                snprintf(dest,dest_size,"add r%d, #0x%02X",Rd,immed);
                 return;
             }
             break;
@@ -1193,9 +1193,9 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                 //LDR Rd,[PC,#nn]
                 u16 Rd = (opcode>>8)&7;
                 u32 offset = (opcode&0xFF)<<2;
-                //s_snprintf(dest,dest_size,"ldr r%d, [pc, #%03X]",Rd,offset);
-                //s_snprintf(dest,dest_size,"ldr r%d, [pc, #0x%03X] =0x%08X",Rd,offset,GBA_MemoryRead32(((address+4)&(~2))+offset));
-                s_snprintf(dest,dest_size,"ldr r%d, =0x%08X",Rd,GBA_MemoryRead32(((address+4)&(~2))+offset));
+                //snprintf(dest,dest_size,"ldr r%d, [pc, #%03X]",Rd,offset);
+                //snprintf(dest,dest_size,"ldr r%d, [pc, #0x%03X] =0x%08X",Rd,offset,GBA_MemoryRead32(((address+4)&(~2))+offset));
+                snprintf(dest,dest_size,"ldr r%d, =0x%08X",Rd,GBA_MemoryRead32(((address+4)&(~2))+offset));
                 return;
             }
             else
@@ -1212,14 +1212,14 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                                 //ADD Rd,Rs
                                 u16 Rd = (opcode&7) | ( (opcode>>4) & 8);
                                 u16 Rs = (opcode>>3)&0xF;
-                                s_snprintf(dest,dest_size,"add r%d, r%d",Rd,Rs);
+                                snprintf(dest,dest_size,"add r%d, r%d",Rd,Rs);
                                 return;
                             }
                             else
                             {
                                 u16 Rd = (opcode&7) | ( (opcode>>4) & 8);
                                 u16 Rs = (opcode>>3)&0xF;
-                                s_snprintf(dest,dest_size,"add r%d, r%d ; [!] (Unused Opcode #4-0)",Rd,Rs);
+                                snprintf(dest,dest_size,"add r%d, r%d ; [!] (Unused Opcode #4-0)",Rd,Rs);
                                 return;
                             }
                         }
@@ -1230,7 +1230,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                                 //CMP Rd,Rs
                                 u16 Rd = (opcode&7) | ( (opcode>>4) & 8);
                                 u16 Rs = (opcode>>3)&0xF;
-                                s_snprintf(dest,dest_size,"cmp r%d, r%d",Rd,Rs);
+                                snprintf(dest,dest_size,"cmp r%d, r%d",Rd,Rs);
                                 return;
                             }
                             else
@@ -1238,7 +1238,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                                 //CMP Rd,Rs
                                 u16 Rd = (opcode&7) | ( (opcode>>4) & 8);
                                 u16 Rs = (opcode>>3)&0xF;
-                                s_snprintf(dest,dest_size,"cmp r%d, r%d ; [!] (Unused Opcode #4-1)",Rd,Rs);
+                                snprintf(dest,dest_size,"cmp r%d, r%d ; [!] (Unused Opcode #4-1)",Rd,Rs);
                                 return;
                             }
                         }
@@ -1252,7 +1252,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                                 if( (Rd == 8) && (Rs == 8) )
                                     s_strncpy(dest,"nop",dest_size);
                                 else
-                                    s_snprintf(dest,dest_size,"mov r%d, r%d",Rd,Rs);
+                                    snprintf(dest,dest_size,"mov r%d, r%d",Rd,Rs);
                                 return;
                             }
                             else //Tested in real hardware
@@ -1263,7 +1263,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                                 if( (Rd == 8) && (Rs == 8) )
                                     s_strncpy(dest,"nop ; [!] (Unused Opcode #4-2)",dest_size);
                                 else
-                                    s_snprintf(dest,dest_size,"mov r%d, r%d ; [!] (Unused Opcode #4-2)",Rd,Rs);
+                                    snprintf(dest,dest_size,"mov r%d, r%d ; [!] (Unused Opcode #4-2)",Rd,Rs);
                                 return;
                             }
                         }
@@ -1287,9 +1287,9 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                                     //BX  Rs
                                     u16 Rs = (opcode>>3)&0xF;
                                     if(CPU.R[Rs]&BIT(0))
-                                        s_snprintf(dest,dest_size,"bx r%d",Rs);
+                                        snprintf(dest,dest_size,"bx r%d",Rs);
                                     else
-                                        s_snprintf(dest,dest_size,"bx r%d ; Switch to ARM",Rs);
+                                        snprintf(dest,dest_size,"bx r%d ; Switch to ARM",Rs);
                                     return;
                                 }
                             }
@@ -1304,7 +1304,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                     u16 Rd = opcode&7;
                     u16 Rs = (opcode>>3)&7;
                     u16 op = (opcode>>6)&0xF;
-                    s_snprintf(dest,dest_size,"%s r%d, r%d",thumb_alu_operation[op],Rd,Rs);
+                    snprintf(dest,dest_size,"%s r%d, r%d",thumb_alu_operation[op],Rd,Rs);
                     return;
                 }
             }
@@ -1322,7 +1322,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                 "str", "strh", "strb", "ldsb", "ldr", "ldrh", "ldrb", "ldsh"
             };
 
-            s_snprintf(dest,dest_size,"%s r%d, [r%d, r%d]",thumb_mem_ops[op],Rd,Rb,Ro);
+            snprintf(dest,dest_size,"%s r%d, [r%d, r%d]",thumb_mem_ops[op],Rd,Rb,Ro);
             gba_dissasemble_add_io_register_name(CPU.R[Rb]+CPU.R[Ro],dest,1,dest_size);
             return;
         }
@@ -1335,17 +1335,17 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
             {
                 //LDR  Rd,[Rb,#nn]
                 if(offset)
-                    s_snprintf(dest,dest_size,"ldr r%d, [r%d, #0x%02X]",Rd,Rb,offset);
+                    snprintf(dest,dest_size,"ldr r%d, [r%d, #0x%02X]",Rd,Rb,offset);
                 else
-                    s_snprintf(dest,dest_size,"ldr r%d, [r%d]",Rd,Rb);
+                    snprintf(dest,dest_size,"ldr r%d, [r%d]",Rd,Rb);
             }
             else
             {
                 //STR  Rd,[Rb,#nn]
                 if(offset)
-                    s_snprintf(dest,dest_size,"str r%d, [r%d, #0x%02X]",Rd,Rb,offset);
+                    snprintf(dest,dest_size,"str r%d, [r%d, #0x%02X]",Rd,Rb,offset);
                 else
-                    s_snprintf(dest,dest_size,"str r%d, [r%d]",Rd,Rb);
+                    snprintf(dest,dest_size,"str r%d, [r%d]",Rd,Rb);
             }
             gba_dissasemble_add_io_register_name(CPU.R[Rb]+offset,dest,1,dest_size);
             return;
@@ -1359,17 +1359,17 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
             {
                 //LDRB Rd,[Rb,#nn]
                 if(offset)
-                    s_snprintf(dest,dest_size,"ldrb r%d, [r%d, #0x%02X]",Rd,Rb,offset);
+                    snprintf(dest,dest_size,"ldrb r%d, [r%d, #0x%02X]",Rd,Rb,offset);
                 else
-                    s_snprintf(dest,dest_size,"ldrb r%d, [r%d]",Rd,Rb);
+                    snprintf(dest,dest_size,"ldrb r%d, [r%d]",Rd,Rb);
             }
             else
             {
                 //STRB Rd,[Rb,#nn]
                 if(offset)
-                    s_snprintf(dest,dest_size,"strb r%d, [r%d, #0x%02X]",Rd,Rb,offset);
+                    snprintf(dest,dest_size,"strb r%d, [r%d, #0x%02X]",Rd,Rb,offset);
                 else
-                    s_snprintf(dest,dest_size,"strb r%d, [r%d]",Rd,Rb);
+                    snprintf(dest,dest_size,"strb r%d, [r%d]",Rd,Rb);
             }
             gba_dissasemble_add_io_register_name(CPU.R[Rb]+offset,dest,1,dest_size);
             return;
@@ -1383,17 +1383,17 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
             {
                 //LDRH Rd,[Rb,#nn]
                 if(offset)
-                    s_snprintf(dest,dest_size,"ldrh r%d, [r%d, #0x%02X]",Rd,Rb,offset);
+                    snprintf(dest,dest_size,"ldrh r%d, [r%d, #0x%02X]",Rd,Rb,offset);
                 else
-                    s_snprintf(dest,dest_size,"ldrh r%d, [r%d]",Rd,Rb);
+                    snprintf(dest,dest_size,"ldrh r%d, [r%d]",Rd,Rb);
             }
             else
             {
                 //STRH Rd,[Rb,#nn]
                 if(offset)
-                    s_snprintf(dest,dest_size,"strh r%d, [r%d, #0x%02X]",Rd,Rb,offset);
+                    snprintf(dest,dest_size,"strh r%d, [r%d, #0x%02X]",Rd,Rb,offset);
                 else
-                    s_snprintf(dest,dest_size,"strh r%d, [r%d]",Rd,Rb);
+                    snprintf(dest,dest_size,"strh r%d, [r%d]",Rd,Rb);
             }
             gba_dissasemble_add_io_register_name(CPU.R[Rb]+offset,dest,1,dest_size);
             return;
@@ -1406,18 +1406,18 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
             {
                 //LDR  Rd,[SP,#nn]
                 if(offset)
-                    s_snprintf(dest,dest_size,"ldr r%d, [sp, #0x%02X]",Rd,offset);
+                    snprintf(dest,dest_size,"ldr r%d, [sp, #0x%02X]",Rd,offset);
                 else
-                    s_snprintf(dest,dest_size,"ldr r%d, [sp]",Rd);
+                    snprintf(dest,dest_size,"ldr r%d, [sp]",Rd);
                 return;
             }
             else
             {
                 //STR  Rd,[SP,#nn]
                 if(offset)
-                    s_snprintf(dest,dest_size,"str r%d, [sp, #0x%02X]",Rd,offset);
+                    snprintf(dest,dest_size,"str r%d, [sp, #0x%02X]",Rd,offset);
                 else
-                    s_snprintf(dest,dest_size,"str r%d, [sp]",Rd);
+                    snprintf(dest,dest_size,"str r%d, [sp]",Rd);
                 return;
             }
             break;
@@ -1430,18 +1430,18 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
             {
                 //ADD  Rd,SP,#nn
                 if(offset)
-                    s_snprintf(dest,dest_size,"add r%d, sp, #0x%03X",Rd,offset);
+                    snprintf(dest,dest_size,"add r%d, sp, #0x%03X",Rd,offset);
                 else
-                    s_snprintf(dest,dest_size,"mov r%d, sp",Rd);
+                    snprintf(dest,dest_size,"mov r%d, sp",Rd);
                 return;
             }
             else
             {
                 //ADD  Rd,PC,#nn
                 if(offset)
-                    s_snprintf(dest,dest_size,"add r%d, pc, #0x%03X",Rd,offset);
+                    snprintf(dest,dest_size,"add r%d, pc, #0x%03X",Rd,offset);
                 else
-                    s_snprintf(dest,dest_size,"mov r%d, pc",Rd);
+                    snprintf(dest,dest_size,"mov r%d, pc",Rd);
                 return;
             }
             break;
@@ -1458,12 +1458,12 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                         if(opcode & BIT(7))
                         {
                             //ADD  SP,#-nn
-                            s_snprintf(dest,dest_size,"add sp, #-0x%02X",offset);
+                            snprintf(dest,dest_size,"add sp, #-0x%02X",offset);
                         }
                         else
                         {
                             //ADD  SP,#nn
-                            s_snprintf(dest,dest_size,"add sp, #0x%02X",offset);
+                            snprintf(dest,dest_size,"add sp, #0x%02X",offset);
                         }
                         return;
                     }
@@ -1478,14 +1478,14 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                     {
                         if(registers & BIT(i))
                         {
-                            char reg[4]; s_snprintf(reg,sizeof(reg),"r%d",i);
+                            char reg[4]; snprintf(reg,sizeof(reg),"r%d",i);
                             s_strncat(reglist,reg,sizeof(reglist));
                             if( (registers & BIT(i+1)) && (registers & BIT(i+2)) )
                             {
                                 s_strncat(reglist,"-",sizeof(reglist));
                                 while(registers & BIT(i++));
                                 i-=2;
-                                s_snprintf(reg,sizeof(reg),"r%d",i);
+                                snprintf(reg,sizeof(reg),"r%d",i);
                                 s_strncat(reglist,reg,sizeof(reglist));
                             }
                             int j = i+1;
@@ -1494,7 +1494,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                         }
                     }
                     s_strncat(reglist,"}",sizeof(reglist));
-                    s_snprintf(dest,dest_size,"push %s",reglist);
+                    snprintf(dest,dest_size,"push %s",reglist);
                     return;
                 }
                 case 3: break;
@@ -1512,14 +1512,14 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                         if(registers & BIT(i))
                         {
                             count ++;
-                            char reg[4]; s_snprintf(reg,sizeof(reg),"r%d",i);
+                            char reg[4]; snprintf(reg,sizeof(reg),"r%d",i);
                             s_strncat(reglist,reg,sizeof(reglist));
                             if( (registers & BIT(i+1)) && (registers & BIT(i+2)) )
                             {
                                 s_strncat(reglist,"-",sizeof(reglist));
                                 while(registers & BIT(i++));
                                 i-=2;
-                                if(i<16) s_snprintf(reg,sizeof(reg),"r%d",i);
+                                if(i<16) snprintf(reg,sizeof(reg),"r%d",i);
                                 else s_strncat(reglist,"pc",sizeof(reglist));
                                 s_strncat(reglist,reg,sizeof(reglist));
                             }
@@ -1530,7 +1530,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                         }
                     }
                     s_strncat(reglist,"}",sizeof(reglist));
-                    s_snprintf(dest,dest_size,"pop %s",reglist);
+                    snprintf(dest,dest_size,"pop %s",reglist);
                     if(count == 0) s_strncat(dest," ; [!] Undefined opcode!",dest_size);
                     return;
                 }
@@ -1550,14 +1550,14 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
             {
                 if(opcode & BIT(i))
                 {
-                    char reg[4]; s_snprintf(reg,sizeof(reg),"r%d",i);
+                    char reg[4]; snprintf(reg,sizeof(reg),"r%d",i);
                     s_strncat(reglist,reg,sizeof(reglist));
                     if( (opcode & BIT(i+1)) && (opcode & BIT(i+2)) )
                     {
                         s_strncat(reglist,"-",sizeof(reglist));
                         while(opcode & BIT(i++));
                         i-=2;
-                        s_snprintf(reg,sizeof(reg),"r%d",i);
+                        snprintf(reg,sizeof(reg),"r%d",i);
                         s_strncat(reglist,reg,sizeof(reglist));
                     }
 
@@ -1573,13 +1573,13 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
             if(opcode & BIT(11))
             {
                 //LDMIA Rb!,{Rlist}
-                s_snprintf(dest,dest_size,"ldmia r%d!,%s",Rb,reglist);
+                snprintf(dest,dest_size,"ldmia r%d!,%s",Rb,reglist);
                 if((opcode&0xFF) == 0) s_strncat(dest," ; [!] Undefined opcode",dest_size);
             }
             else
             {
                 //STMIA Rb!,{Rlist}
-                s_snprintf(dest,dest_size,"stmia r%d!,%s",Rb,reglist);
+                snprintf(dest,dest_size,"stmia r%d!,%s",Rb,reglist);
                 if((opcode&0xFF) == 0) s_strncat(dest," ; [!] Rb += 0x40",dest_size);
             }
             return;
@@ -1591,7 +1591,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
             if(cond == 15)
             {
                 //SWI nn
-                s_snprintf(dest,dest_size,"swi #0x%02X",data);
+                snprintf(dest,dest_size,"swi #0x%02X",data);
                 gba_disassemble_swi_name(data,dest,1,dest_size);
                 return;
             }
@@ -1599,7 +1599,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
             {
                 //Undefined opcode -- Tested in real hardware
                 u32 addr_dest = address+4+ ( ((s16)(s8)data) << 1 );
-                s_snprintf(dest,dest_size,"b{al} #0x%08X ; [!] (Undefined Opcode #D)", addr_dest);
+                snprintf(dest,dest_size,"b{al} #0x%08X ; [!] (Undefined Opcode #D)", addr_dest);
                 if(addr_dest > address) s_strncat(dest," ; " STR_SLIM_ARROW_DOWN,dest_size);
                 else if(addr_dest == address) s_strncat(dest," ; <-",dest_size);
                 else s_strncat(dest," ; " STR_SLIM_ARROW_UP,dest_size);
@@ -1609,7 +1609,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
             {
                 //B{cond} label
                 u32 addr_dest = address+4+ ( ((s16)(s8)data) << 1 );
-                s_snprintf(dest,dest_size,"b%s #0x%08X",arm_cond[cond], addr_dest);
+                snprintf(dest,dest_size,"b%s #0x%08X",arm_cond[cond], addr_dest);
                 if(addr_dest > address) s_strncat(dest," ; " STR_SLIM_ARROW_DOWN,dest_size);
                 else if(addr_dest == address) s_strncat(dest," ; <-",dest_size);
                 else s_strncat(dest," ; " STR_SLIM_ARROW_UP,dest_size);
@@ -1631,7 +1631,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                 s32 offset = (opcode&0x3FF)<<1;
                 if(offset & BIT(10)) { offset |= 0xFFFFF800; }
                 u32 addr_dest = address+4+offset;
-                s_snprintf(dest,dest_size,"b #0x%08X",addr_dest);
+                snprintf(dest,dest_size,"b #0x%08X",addr_dest);
                 if(addr_dest > address) s_strncat(dest," ; "STR_SLIM_ARROW_DOWN,dest_size);
                 else if(addr_dest == address) s_strncat(dest," ; <-",dest_size);
                 else s_strncat(dest," ; "STR_SLIM_ARROW_UP,dest_size);
@@ -1662,7 +1662,7 @@ void GBA_DisassembleTHUMB(u16 opcode, u32 address, char * dest, int dest_size)
                 if((next & 0xF800) == 0xF800)
                 {
                     u32 addr = address + 4 + ((((u32)opcode & 0x7FF) << 12) | ((u32)opcode&BIT(10)?0xFF800000:0)) + ((next & 0x7FF) << 1);
-                    s_snprintf(dest,dest_size,"bl #0x%08X",addr);
+                    snprintf(dest,dest_size,"bl #0x%08X",addr);
                     s_strncat(dest," ; ->",dest_size);
                     return;
                 }

--- a/gba_core/dma.c
+++ b/gba_core/dma.c
@@ -121,7 +121,7 @@ void GBA_DMA0Setup(void)
     }
 
 /*
-    char text[64]; s_snprintf(text,sizeof(text),"DMA0 SETUP\nMODE: %d\nSRC: %08X (%d)\nDST: %08X (%d)\n"
+    char text[64]; snprintf(text,sizeof(text),"DMA0 SETUP\nMODE: %d\nSRC: %08X (%d)\nDST: %08X (%d)\n"
         "CHUNK: %08X"
         ,DMA[0].starttime,DMA[0].srcaddr,DMA[0].srcadd,DMA[0].dstaddr,DMA[0].dstadd,
         DMA[0].num_chunks);
@@ -281,7 +281,7 @@ void GBA_DMA3Setup(void)
 
     if(DMA[3].starttime == START_NOW) { gba_dmaworking = 1; GBA_ExecutionBreak(); }
 /*
-    char text[64]; s_snprintf(text,sizeof(text),"DMA3 SETUP\nMODE: %d\nSRC: %08X (%d)\nDST: %08X (%d)\n"
+    char text[64]; snprintf(text,sizeof(text),"DMA3 SETUP\nMODE: %d\nSRC: %08X (%d)\nDST: %08X (%d)\n"
         "CHUNK: %08X"
         ,DMA[3].starttime,DMA[3].srcaddr,DMA[3].srcadd,DMA[3].dstaddr,DMA[3].dstadd,
         DMA[3].num_chunks);
@@ -398,7 +398,7 @@ static inline s32 GBA_DMA1Update(s32 clocks) //return clocks to finish transfer
 
     if(DMA[1].starttime == START_SPECIAL)
     {
-        //char text[64]; s_snprintf(text,sizeof(text),"DMA1, MODE: %d",DMA[1].starttime);
+        //char text[64]; snprintf(text,sizeof(text),"DMA1, MODE: %d",DMA[1].starttime);
         //MessageBox(NULL, text, "EMULATION", MB_OK);
         //GBA_ExecutionBreak();
         DMA[1].enabled = 0;
@@ -509,7 +509,7 @@ static inline s32 GBA_DMA2Update(s32 clocks) //return clocks to finish transfer
 
     if(DMA[2].starttime == START_SPECIAL)
     {
-        //char text[64]; s_snprintf(text,sizeof(text),"DMA1, MODE: %d",DMA[1].starttime);
+        //char text[64]; snprintf(text,sizeof(text),"DMA1, MODE: %d",DMA[1].starttime);
         //MessageBox(NULL, text, "EMULATION", MB_OK);
         //GBA_ExecutionBreak();
         DMA[2].enabled = 0;
@@ -659,7 +659,7 @@ static inline s32 GBA_DMA3Update(s32 clocks) //return clocks to finish transfer
             //MessageBox(NULL, "DMA 3 copy", "EMULATION", MB_OK);
             //GBA_ExecutionBreak();
 
-            //char text[64]; s_snprintf(text,sizeof(text),"DMA3\nSRC: %08X\nDST: %08X\nCHUNCKS: %08X",
+            //char text[64]; snprintf(text,sizeof(text),"DMA3\nSRC: %08X\nDST: %08X\nCHUNCKS: %08X",
             //    DMA[3].srcaddr,DMA[3].dstaddr,DMA[3].num_chunks);
             //MessageBox(NULL, text, "EMULATION", MB_OK);
             //GBA_ExecutionBreak();

--- a/general_utils.c
+++ b/general_utils.c
@@ -26,16 +26,6 @@
 
 //----------------------------------------------------------------------------------
 
-int s_snprintf(char * dest, int _size, const char * msg, ...)
-{
-    va_list args;
-    va_start(args,msg);
-    int ret = vsnprintf(dest, _size, msg, args);
-    va_end(args);
-    dest[_size-1] = '\0';
-    return ret;
-}
-
 void s_strncpy(char * dest, const char * src, int _size)
 {
     strncpy(dest,src,_size);

--- a/general_utils.h
+++ b/general_utils.h
@@ -34,10 +34,7 @@ typedef signed char s8;
 
 //----------------------------------------------------------------------------------
 
-//safe versions of snprintf, strncpy and strncat that set a terminating character if needed.
-//strncpy doesn't set it, and I'd say I've seen implementations of strncat and snprinf that
-//doesn't, either.
-int s_snprintf(char * dest, int _size, const char * msg, ...);
+//safe versions of strncpy and strncat that set a terminating character if needed.
 void s_strncpy(char * dest, const char * src, int _size);
 void s_strncat(char * dest, const char * src, int _size);
 

--- a/gui/win_gb_memviewer.c
+++ b/gui/win_gb_memviewer.c
@@ -103,14 +103,14 @@ void Win_GBMemViewerUpdate(void)
         int i;
         for(i = 0; i < GB_MEMVIEWER_MAX_LINES; i++)
         {
-            s_snprintf(textbuf,sizeof(textbuf),"%04X : ",address);
+            snprintf(textbuf,sizeof(textbuf),"%04X : ",address);
 
             u16 tmpaddr = address;
             int j;
             for(j = 0; j < 8; j ++)
             {
                 char tmp[30];
-                s_snprintf(tmp,sizeof(tmp),"%04X ",GB_MemRead16(tmpaddr));
+                snprintf(tmp,sizeof(tmp),"%04X ",GB_MemRead16(tmpaddr));
                 s_strncat(textbuf,tmp,sizeof(textbuf));
                 tmpaddr += 2;
             }
@@ -120,7 +120,7 @@ void Win_GBMemViewerUpdate(void)
             for(j = 0; j < 16; j ++)
             {
                 char tmp[30];
-                s_snprintf(tmp,sizeof(tmp),"%c",win_gb_memviewer_character_fix(GB_MemRead8(tmpaddr)));
+                snprintf(tmp,sizeof(tmp),"%c",win_gb_memviewer_character_fix(GB_MemRead8(tmpaddr)));
                 if((j&3) == 3) s_strncat(tmp," ",sizeof(tmp));
                 s_strncat(textbuf,tmp,sizeof(textbuf));
                 tmpaddr ++;
@@ -136,14 +136,14 @@ void Win_GBMemViewerUpdate(void)
         int i;
         for(i = 0; i < GB_MEMVIEWER_MAX_LINES; i++)
         {
-            s_snprintf(textbuf,sizeof(textbuf),"%04X : ",address);
+            snprintf(textbuf,sizeof(textbuf),"%04X : ",address);
 
             u16 tmpaddr = address;
             int j;
             for(j = 0; j < 16; j ++)
             {
                 char tmp[30];
-                s_snprintf(tmp,sizeof(tmp),"%02X ",GB_MemRead8(tmpaddr));
+                snprintf(tmp,sizeof(tmp),"%02X ",GB_MemRead8(tmpaddr));
                 s_strncat(textbuf,tmp,sizeof(textbuf));
                 tmpaddr ++;
             }
@@ -153,7 +153,7 @@ void Win_GBMemViewerUpdate(void)
             for(j = 0; j < 16; j ++)
             {
                 char tmp[30];
-                s_snprintf(tmp,sizeof(tmp),"%c",win_gb_memviewer_character_fix(GB_MemRead8(tmpaddr)));
+                snprintf(tmp,sizeof(tmp),"%c",win_gb_memviewer_character_fix(GB_MemRead8(tmpaddr)));
                 if((j&3) == 3) s_strncat(tmp," ",sizeof(tmp));
                 s_strncat(textbuf,tmp,sizeof(textbuf));
                 tmpaddr ++;
@@ -346,7 +346,7 @@ static void _win_gb_mem_view_textbox_callback(int x, int y)
         gb_memviewer_clicked_address = clicked_addr;
         gb_memviewer_inputwindow_is_goto = 0;
         char caption[100];
-        s_snprintf(caption,sizeof(caption),"Change [0x%04X] (%d bits)",clicked_addr,numbits);
+        snprintf(caption,sizeof(caption),"Change [0x%04X] (%d bits)",clicked_addr,numbits);
         GUI_InputWindowOpen(&gui_iw_gb_memviewer,caption,_win_gb_mem_viewer_inputwindow_callback);
     }
 }

--- a/gui/win_gb_tileviewer.c
+++ b/gui/win_gb_tileviewer.c
@@ -150,7 +150,7 @@ void Win_GBTileViewerUpdate(void)
     }
 
     char text[8];
-    s_snprintf(text,sizeof(text),"Pal: %d",gb_tile_zoomed_tile_sel_pal);
+    snprintf(text,sizeof(text),"Pal: %d",gb_tile_zoomed_tile_sel_pal);
     GUI_SetLabelCaption(&gb_tileview_zoomed_tile_pal_label,text);
 
     GUI_Draw_SetDrawingColor(255,0,0);

--- a/gui/win_gba_disassembler.c
+++ b/gui/win_gba_disassembler.c
@@ -144,11 +144,11 @@ void Win_GBADisassemblerUpdate(void)
     GUI_ConsoleModePrintf(&gba_regs_con,0,18,"              ");
 
     char text[80];
-    s_snprintf(text,sizeof(text),"N:%d Z:%d C:%d V:%d", (cpu->CPSR&F_N) != 0, (cpu->CPSR&F_Z) != 0,
+    snprintf(text,sizeof(text),"N:%d Z:%d C:%d V:%d", (cpu->CPSR&F_N) != 0, (cpu->CPSR&F_Z) != 0,
             (cpu->CPSR&F_C) != 0, (cpu->CPSR&F_V) != 0);
     GUI_ConsoleModePrintf(&gba_regs_con,0,19,text);
 
-    s_snprintf(text,sizeof(text),"I:%d F:%d     T:%d", (cpu->CPSR&F_I) != 0, (cpu->CPSR&F_F) != 0,
+    snprintf(text,sizeof(text),"I:%d F:%d     T:%d", (cpu->CPSR&F_I) != 0, (cpu->CPSR&F_F) != 0,
             (cpu->CPSR&F_T) != 0);
     GUI_ConsoleModePrintf(&gba_regs_con,0,20,text);
 
@@ -157,7 +157,7 @@ void Win_GBADisassemblerUpdate(void)
         "user","fiq","irq","svc","abort","undef.", "system"
     };
 
-    s_snprintf(text,sizeof(text),"Mode:%02X (%s)", cpu->CPSR&0x1F, cpu_modes[cpu->MODE]);
+    snprintf(text,sizeof(text),"Mode:%02X (%s)", cpu->CPSR&0x1F, cpu_modes[cpu->MODE]);
     GUI_ConsoleModePrintf(&gba_regs_con,0,21,text);
 
     //DISASSEMBLER
@@ -175,7 +175,7 @@ void Win_GBADisassemblerUpdate(void)
             u32 opcode = GBA_MemoryReadFast32(address);
 
             GBA_DisassembleARM(opcode,address,opcode_text,sizeof(opcode_text));
-            s_snprintf(final_text,sizeof(final_text),"%08X:%08X %s",address,opcode,opcode_text);
+            snprintf(final_text,sizeof(final_text),"%08X:%08X %s",address,opcode,opcode_text);
 
             GUI_ConsoleModePrintf(&gba_disassembly_con,0,i,final_text);
 
@@ -201,7 +201,7 @@ void Win_GBADisassemblerUpdate(void)
             u16 opcode = GBA_MemoryReadFast16(address);
 
             GBA_DisassembleTHUMB(opcode,address,opcode_text,sizeof(opcode_text));
-            s_snprintf(final_text,sizeof(final_text),"%08X:%04X %s",address,opcode,opcode_text);
+            snprintf(final_text,sizeof(final_text),"%08X:%04X %s",address,opcode,opcode_text);
 
             GUI_ConsoleModePrintf(&gba_disassembly_con,0,i,final_text);
 
@@ -407,11 +407,11 @@ static void _win_gba_registers_textbox_callback(int x, int y)
 
     char text[30];
     if(reg < 16)
-        s_snprintf(text,sizeof(text),"New value for r%d",reg);
+        snprintf(text,sizeof(text),"New value for r%d",reg);
     else if(reg == 16)
-        s_snprintf(text,sizeof(text),"New value for cpsr");
+        snprintf(text,sizeof(text),"New value for cpsr");
     else if(reg == 17)
-        s_snprintf(text,sizeof(text),"New value for spsr");
+        snprintf(text,sizeof(text),"New value for spsr");
     else
         return;
 

--- a/gui/win_gba_ioviewer.c
+++ b/gui/win_gba_ioviewer.c
@@ -459,8 +459,8 @@ void Win_GBAIOViewerUpdate(void)
 
                 int bg2x = REG_BG2X; if(bg2x&BIT(27)) bg2x |= 0xF0000000;
                 int bg2y = REG_BG2Y; if(bg2y&BIT(27)) bg2y |= 0xF0000000;
-                char text_x[9]; s_snprintf(text_x,sizeof(text_x),"%.8f",((float)bg2x)/(1<<8));
-                char text_y[9]; s_snprintf(text_y,sizeof(text_y),"%.8f",((float)bg2y)/(1<<8));
+                char text_x[9]; snprintf(text_x,sizeof(text_x),"%.8f",((float)bg2x)/(1<<8));
+                char text_y[9]; snprintf(text_y,sizeof(text_y),"%.8f",((float)bg2y)/(1<<8));
                 GUI_ConsoleModePrintf(&gba_ioview_bgs_affine_con,2,3, "(%s,%s)",text_x,text_y);
 
                 GUI_ConsoleModePrintf(&gba_ioview_bgs_affine_con,2,7, "    [%04X,%04X]",REG_BG2PA,REG_BG2PB);
@@ -468,10 +468,10 @@ void Win_GBAIOViewerUpdate(void)
 
                 int pa = (s32)(s16)REG_BG2PA; int pb = (s32)(s16)REG_BG2PB;
                 int pc = (s32)(s16)REG_BG2PC; int pd = (s32)(s16)REG_BG2PD;
-                char text_a[7]; s_snprintf(text_a,sizeof(text_a),"%.8f",((float)pa)/(1<<8));
-                char text_b[7]; s_snprintf(text_b,sizeof(text_b),"%.8f",((float)pb)/(1<<8));
-                char text_c[7]; s_snprintf(text_c,sizeof(text_c),"%.8f",((float)pc)/(1<<8));
-                char text_d[7]; s_snprintf(text_d,sizeof(text_d),"%.8f",((float)pd)/(1<<8));
+                char text_a[7]; snprintf(text_a,sizeof(text_a),"%.8f",((float)pa)/(1<<8));
+                char text_b[7]; snprintf(text_b,sizeof(text_b),"%.8f",((float)pb)/(1<<8));
+                char text_c[7]; snprintf(text_c,sizeof(text_c),"%.8f",((float)pc)/(1<<8));
+                char text_d[7]; snprintf(text_d,sizeof(text_d),"%.8f",((float)pd)/(1<<8));
                 GUI_ConsoleModePrintf(&gba_ioview_bgs_affine_con,2,9,  "  (%s,%s)",text_a,text_b);
                 GUI_ConsoleModePrintf(&gba_ioview_bgs_affine_con,2,10, "  (%s,%s)",text_c,text_d);
             }
@@ -491,8 +491,8 @@ void Win_GBAIOViewerUpdate(void)
 
                 int bg3x = REG_BG3X; if(bg3x&BIT(27)) bg3x |= 0xF0000000;
                 int bg3y = REG_BG3Y; if(bg3y&BIT(27)) bg3y |= 0xF0000000;
-                char text_x[9]; s_snprintf(text_x,sizeof(text_x),"%.8f",((float)bg3x)/(1<<8));
-                char text_y[9]; s_snprintf(text_y,sizeof(text_y),"%.8f",((float)bg3y)/(1<<8));
+                char text_x[9]; snprintf(text_x,sizeof(text_x),"%.8f",((float)bg3x)/(1<<8));
+                char text_y[9]; snprintf(text_y,sizeof(text_y),"%.8f",((float)bg3y)/(1<<8));
                 GUI_ConsoleModePrintf(&gba_ioview_bgs_affine_con,26,3, "(%s,%s)",text_x,text_y);
 
                 GUI_ConsoleModePrintf(&gba_ioview_bgs_affine_con,26,7, "    [%04X,%04X]",REG_BG3PA,REG_BG3PB);
@@ -500,10 +500,10 @@ void Win_GBAIOViewerUpdate(void)
 
                 int pa = (s32)(s16)REG_BG3PA; int pb = (s32)(s16)REG_BG3PB;
                 int pc = (s32)(s16)REG_BG3PC; int pd = (s32)(s16)REG_BG3PD;
-                char text_a[7]; s_snprintf(text_a,sizeof(text_a),"%.8f",((float)pa)/(1<<8));
-                char text_b[7]; s_snprintf(text_b,sizeof(text_b),"%.8f",((float)pb)/(1<<8));
-                char text_c[7]; s_snprintf(text_c,sizeof(text_c),"%.8f",((float)pc)/(1<<8));
-                char text_d[7]; s_snprintf(text_d,sizeof(text_d),"%.8f",((float)pd)/(1<<8));
+                char text_a[7]; snprintf(text_a,sizeof(text_a),"%.8f",((float)pa)/(1<<8));
+                char text_b[7]; snprintf(text_b,sizeof(text_b),"%.8f",((float)pb)/(1<<8));
+                char text_c[7]; snprintf(text_c,sizeof(text_c),"%.8f",((float)pc)/(1<<8));
+                char text_d[7]; snprintf(text_d,sizeof(text_d),"%.8f",((float)pd)/(1<<8));
                 GUI_ConsoleModePrintf(&gba_ioview_bgs_affine_con,26,9,  "  (%s,%s)",text_a,text_b);
                 GUI_ConsoleModePrintf(&gba_ioview_bgs_affine_con,26,10, "  (%s,%s)",text_c,text_d);
             }
@@ -742,7 +742,7 @@ void Win_GBAIOViewerUpdate(void)
             GUI_ConsoleModePrintf(&gba_ioview_sound_chn1_con,0,4, "[%2d] Volume",gba_debug_get_psg_vol(1));
 
             char text_freq[10];
-            s_snprintf(text_freq,sizeof(text_freq),"%9.2f", 131072.0/(float)(2048-(REG_SOUND1CNT_X&0x7FF)));
+            snprintf(text_freq,sizeof(text_freq),"%9.2f", 131072.0/(float)(2048-(REG_SOUND1CNT_X&0x7FF)));
             GUI_ConsoleModePrintf(&gba_ioview_sound_chn1_con,0,5, "[%s] Frequency",text_freq);
 
             // Channel 2
@@ -754,7 +754,7 @@ void Win_GBAIOViewerUpdate(void)
 
             GUI_ConsoleModePrintf(&gba_ioview_sound_chn2_con,0,4, "[%2d] Volume",gba_debug_get_psg_vol(2));
 
-            s_snprintf(text_freq,sizeof(text_freq),"%9.2f", 131072.0/(float)(2048-(REG_SOUND2CNT_H&0x7FF)));
+            snprintf(text_freq,sizeof(text_freq),"%9.2f", 131072.0/(float)(2048-(REG_SOUND2CNT_H&0x7FF)));
             GUI_ConsoleModePrintf(&gba_ioview_sound_chn2_con,0,5, "[%s] Frequency",text_freq);
 
             // Channel 3
@@ -767,7 +767,7 @@ void Win_GBAIOViewerUpdate(void)
 
             GUI_ConsoleModePrintf(&gba_ioview_sound_chn3_con,0,4, "[%2d] Volume",gba_debug_get_psg_vol(3));
 
-            s_snprintf(text_freq,sizeof(text_freq),"%9.2f", 2097152.0/(float)(2048-(REG_SOUND3CNT_X&0x7FF)));
+            snprintf(text_freq,sizeof(text_freq),"%9.2f", 2097152.0/(float)(2048-(REG_SOUND3CNT_X&0x7FF)));
             GUI_ConsoleModePrintf(&gba_ioview_sound_chn3_con,0,5, "[%s] Frequency",text_freq);
 
             // Channel 4

--- a/gui/win_gba_memviewer.c
+++ b/gui/win_gba_memviewer.c
@@ -105,14 +105,14 @@ void Win_GBAMemViewerUpdate(void)
         int i;
         for(i = 0; i < GBA_MEMVIEWER_MAX_LINES; i++)
         {
-            s_snprintf(textbuf,sizeof(textbuf),"%08X : ",address);
+            snprintf(textbuf,sizeof(textbuf),"%08X : ",address);
 
             u32 tmpaddr = address;
             int j;
             for(j = 0; j < 4; j ++)
             {
                 char tmp[30];
-                s_snprintf(tmp,sizeof(tmp),"%08X ",GBA_MemoryReadFast32(tmpaddr));
+                snprintf(tmp,sizeof(tmp),"%08X ",GBA_MemoryReadFast32(tmpaddr));
                 s_strncat(textbuf,tmp,sizeof(textbuf));
                 tmpaddr += 4;
             }
@@ -122,7 +122,7 @@ void Win_GBAMemViewerUpdate(void)
             for(j = 0; j < 16; j ++)
             {
                 char tmp[30];
-                s_snprintf(tmp,sizeof(tmp),"%c",win_gba_memviewer_character_fix(GBA_MemoryReadFast8(tmpaddr)));
+                snprintf(tmp,sizeof(tmp),"%c",win_gba_memviewer_character_fix(GBA_MemoryReadFast8(tmpaddr)));
                 if((j&3) == 3) s_strncat(tmp," ",sizeof(tmp));
                 s_strncat(textbuf,tmp,sizeof(textbuf));
                 tmpaddr ++;
@@ -138,14 +138,14 @@ void Win_GBAMemViewerUpdate(void)
         int i;
         for(i = 0; i < GBA_MEMVIEWER_MAX_LINES; i++)
         {
-            s_snprintf(textbuf,sizeof(textbuf),"%08X : ",address);
+            snprintf(textbuf,sizeof(textbuf),"%08X : ",address);
 
             u32 tmpaddr = address;
             int j;
             for(j = 0; j < 8; j ++)
             {
                 char tmp[30];
-                s_snprintf(tmp,sizeof(tmp),"%04X ",GBA_MemoryReadFast16(tmpaddr));
+                snprintf(tmp,sizeof(tmp),"%04X ",GBA_MemoryReadFast16(tmpaddr));
                 s_strncat(textbuf,tmp,sizeof(textbuf));
                 tmpaddr += 2;
             }
@@ -155,7 +155,7 @@ void Win_GBAMemViewerUpdate(void)
             for(j = 0; j < 16; j ++)
             {
                 char tmp[30];
-                s_snprintf(tmp,sizeof(tmp),"%c",win_gba_memviewer_character_fix(GBA_MemoryReadFast8(tmpaddr)));
+                snprintf(tmp,sizeof(tmp),"%c",win_gba_memviewer_character_fix(GBA_MemoryReadFast8(tmpaddr)));
                 if((j&3) == 3) s_strncat(tmp," ",sizeof(tmp));
                 s_strncat(textbuf,tmp,sizeof(textbuf));
                 tmpaddr ++;
@@ -171,14 +171,14 @@ void Win_GBAMemViewerUpdate(void)
         int i;
         for(i = 0; i < GBA_MEMVIEWER_MAX_LINES; i++)
         {
-            s_snprintf(textbuf,sizeof(textbuf),"%08X : ",address);
+            snprintf(textbuf,sizeof(textbuf),"%08X : ",address);
 
             u32 tmpaddr = address;
             int j;
             for(j = 0; j < 16; j ++)
             {
                 char tmp[30];
-                s_snprintf(tmp,sizeof(tmp),"%02X ",GBA_MemoryReadFast8(tmpaddr));
+                snprintf(tmp,sizeof(tmp),"%02X ",GBA_MemoryReadFast8(tmpaddr));
                 s_strncat(textbuf,tmp,sizeof(textbuf));
                 tmpaddr ++;
             }
@@ -188,7 +188,7 @@ void Win_GBAMemViewerUpdate(void)
             for(j = 0; j < 16; j ++)
             {
                 char tmp[30];
-                s_snprintf(tmp,sizeof(tmp),"%c",win_gba_memviewer_character_fix(GBA_MemoryReadFast8(tmpaddr)));
+                snprintf(tmp,sizeof(tmp),"%c",win_gba_memviewer_character_fix(GBA_MemoryReadFast8(tmpaddr)));
                 if((j&3) == 3) s_strncat(tmp," ",sizeof(tmp));
                 s_strncat(textbuf,tmp,sizeof(textbuf));
                 tmpaddr ++;
@@ -404,7 +404,7 @@ static void _win_gba_mem_view_textbox_callback(int x, int y)
         gba_memviewer_clicked_address = clicked_addr;
         gba_memviewer_inputwindow_is_goto = 0;
         char caption[100];
-        s_snprintf(caption,sizeof(caption),"Change [0x%08X] (%d bits)",clicked_addr,numbits);
+        snprintf(caption,sizeof(caption),"Change [0x%08X] (%d bits)",clicked_addr,numbits);
         GUI_InputWindowOpen(&gui_iw_gba_memviewer,caption,_win_gba_mem_viewer_inputwindow_callback);
     }
 }

--- a/gui/win_gba_sprviewer.c
+++ b/gui/win_gba_sprviewer.c
@@ -194,10 +194,10 @@ void Win_GBASprViewerUpdate(void)
     GUI_ConsoleModePrintf(&gba_sprview_matrixinfo_con,0,2,"     [%04X,%04X]",(u16)pa,(u16)pb);
     GUI_ConsoleModePrintf(&gba_sprview_matrixinfo_con,0,3,"     [%04X,%04X]",(u16)pc,(u16)pd);
 
-    char text_a[7]; s_snprintf(text_a,sizeof(text_a),"%.8f",((float)pa)/(1<<8));
-    char text_b[7]; s_snprintf(text_b,sizeof(text_b),"%.8f",((float)pb)/(1<<8));
-    char text_c[7]; s_snprintf(text_c,sizeof(text_c),"%.8f",((float)pc)/(1<<8));
-    char text_d[7]; s_snprintf(text_d,sizeof(text_d),"%.8f",((float)pd)/(1<<8));
+    char text_a[7]; snprintf(text_a,sizeof(text_a),"%.8f",((float)pa)/(1<<8));
+    char text_b[7]; snprintf(text_b,sizeof(text_b),"%.8f",((float)pb)/(1<<8));
+    char text_c[7]; snprintf(text_c,sizeof(text_c),"%.8f",((float)pc)/(1<<8));
+    char text_d[7]; snprintf(text_d,sizeof(text_d),"%.8f",((float)pd)/(1<<8));
     GUI_ConsoleModePrintf(&gba_sprview_matrixinfo_con,0,5, "   (%s,%s)",text_a,text_b);
     GUI_ConsoleModePrintf(&gba_sprview_matrixinfo_con,0,6, "   (%s,%s)",text_c,text_d);
 }

--- a/gui/win_main.c
+++ b/gui/win_main.c
@@ -114,10 +114,10 @@ static Uint32 _fps_callback_function(Uint32 interval, void *param)
     WinMain_frames_drawn = 0;
     char caption[60];
     if(_win_main_frameskip > 0)
-        s_snprintf(caption,sizeof(caption),"GiiBiiAdvance: %d fps - %.2f%% - (%d)",WinMain_FPS,
+        snprintf(caption,sizeof(caption),"GiiBiiAdvance: %d fps - %.2f%% - (%d)",WinMain_FPS,
                    (float)WinMain_FPS*10.0f/6.0f,_win_main_frameskip);
     else
-        s_snprintf(caption,sizeof(caption),"GiiBiiAdvance: %d fps - %.2f%%",WinMain_FPS,(float)WinMain_FPS*10.0f/6.0f);
+        snprintf(caption,sizeof(caption),"GiiBiiAdvance: %d fps - %.2f%%",WinMain_FPS,(float)WinMain_FPS*10.0f/6.0f);
     WH_SetCaption(WinIDMain,caption);
 
     return interval;
@@ -392,7 +392,7 @@ static int _win_main_load_rom_autodetect(char * path)
 
         char bios_path[MAX_PATHLEN];
         unsigned int bios_size;
-        s_snprintf(bios_path,sizeof(bios_path),"%s"GBA_BIOS_FILENAME,DirGetBiosFolderPath());
+        snprintf(bios_path,sizeof(bios_path),"%s"GBA_BIOS_FILENAME,DirGetBiosFolderPath());
 
         FileLoad_NoError(bios_path,&bios_buffer,&bios_size); // don't show error messages...
 

--- a/gui/win_main_config.c
+++ b/gui/win_main_config.c
@@ -272,7 +272,7 @@ static void _win_main_config_update_gbpal_info(void)
     GB_ConfigGetPalette(&r,&g,&b);
 
     char text[40];
-    s_snprintf(text,sizeof(text),"GB Palette: (%2d,%2d,%2d)",r/8,g/8,b/8);
+    snprintf(text,sizeof(text),"GB Palette: (%2d,%2d,%2d)",r/8,g/8,b/8);
     GUI_SetLabelCaption(&mainwindow_configwin_gameboy_palette_label,text);
 
     int i;
@@ -429,7 +429,7 @@ void Win_MainCreateConfigWindow(void)
     u8 r,g,b;
     GB_ConfigGetPalette(&r,&g,&b);
     char text[40];
-    s_snprintf(text,sizeof(text),"GB Palette: (%2d,%2d,%2d)",r/8,g/8,b/8);
+    snprintf(text,sizeof(text),"GB Palette: (%2d,%2d,%2d)",r/8,g/8,b/8);
     GUI_SetLabel(&mainwindow_configwin_gameboy_palette_label,12,320,-1,FONT_HEIGHT,text);
     GUI_SetScrollBar(&mainwindow_configwin_gameboy_pal_r_scrollbar,12,338,172,10,
                      0,31,r/8,_win_main_config_gbpal_r_scrollbar_callback);

--- a/input_utils.c
+++ b/input_utils.c
@@ -217,7 +217,7 @@ void Input_GetJoystickElementName(char * name, int namelen, int btncode)
         int is_btn_positive = (btncode&KEYCODE_POSITIVE_AXIS);
         btncode &= ~KEYCODE_POSITIVE_AXIS; //remove positive flag
 
-        s_snprintf(name,namelen,"Axis %d%c",btncode,is_btn_positive?'+':'-');
+        snprintf(name,namelen,"Axis %d%c",btncode,is_btn_positive?'+':'-');
     }
     else if(btncode & KEYCODE_IS_HAT) // axis
     {
@@ -233,11 +233,11 @@ void Input_GetJoystickElementName(char * name, int namelen, int btncode)
         else if(position & SDL_HAT_DOWN) dir = "Down";
         else if(position & SDL_HAT_LEFT) dir = "Left";
 
-        s_snprintf(name,namelen,"Hat %d %s",hat_index,dir);
+        snprintf(name,namelen,"Hat %d %s",hat_index,dir);
     }
     else // button
     {
-        s_snprintf(name,namelen,"Button %d",btncode);
+        snprintf(name,namelen,"Button %d",btncode);
     }
 }
 


### PR DESCRIPTION
`snprintf` is defined by the ISO C standard, which explicitly states that it null terminates:

```
         #include <stdio.h>
         int snprintf(char * restrict s, size_t n,
              const char * restrict format, ...);
```

“The `snprintf` function is equivalent to `fprintf`, except that the output is written into an array (specified by argument *s*) rather than to a stream. If *n* is zero, nothing is written, and *s* may be a null pointer. Otherwise, output characters beyond the *n*−1st are discarded rather than being written to the array, and a null character is written at the end of the characters actually written into the array.”

The odds of encountering a non‐conforming libc in this respect are nil.