### PR TITLE
Missed include for snprintf().

### DIFF
--- a/file_explorer.c
+++ b/file_explorer.c
@@ -20,6 +20,7 @@
 #include <sys/stat.h>
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <string.h>
 #include <ctype.h>
 


### PR DESCRIPTION
file_explorer.c:208: warning: incompatible implicit declaration of built-in function 'snprintf'